### PR TITLE
chore: email templates are now written as .html files

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,6 +3,8 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": ["**/*.html"],
+    "watchAssets": true
   }
 }

--- a/src/common/email/assemble-template.ts
+++ b/src/common/email/assemble-template.ts
@@ -1,8 +1,6 @@
-/* eslint-disable @typescript-eslint/ban-types */
-import footer from './templates/common/footer';
-import header from './templates/common/header';
 import * as templates from './templates';
 import { AllTypes } from './templates/enums';
+import { getHtmlString } from './templates/utils';
 
 export default function assembleTemplate(
   type: AllTypes,
@@ -23,11 +21,11 @@ export default function assembleTemplate(
 
   const wholeTemplate = `
   <div style="display: block; width: 500px;">
-      ${header}
+      ${getHtmlString('header.html')}
 
       ${templateBody}
 
-      ${footer}
+      ${getHtmlString('footer.html')}
     </div>
     `;
 

--- a/src/common/email/templates/common/footer.ts
+++ b/src/common/email/templates/common/footer.ts
@@ -1,7 +1,0 @@
-export default `
-<div
-  class="footer"
-  style="background-color: #f2f2f2; padding: 20px; text-align: center">
-  <p>&copy; Sem copyright aqui, é um projeto open-source :)</p>
-</div>
-`;

--- a/src/common/email/templates/common/header.ts
+++ b/src/common/email/templates/common/header.ts
@@ -1,7 +1,0 @@
-export default `
-  <div
-    class="header"
-    style="background-color: #f2f2f2; padding: 20px; text-align: center">
-    <h1>Financial Planner App</h1>
-  </div>
-`;

--- a/src/common/email/templates/html/footer.html
+++ b/src/common/email/templates/html/footer.html
@@ -1,0 +1,3 @@
+<div style="background-color: #f2f2f2; padding: 20px; text-align: center">
+  <p>&copy; Sem copyright aqui, é um projeto open-source :)</p>
+</div>

--- a/src/common/email/templates/html/header.html
+++ b/src/common/email/templates/html/header.html
@@ -1,0 +1,3 @@
+<div style="background-color: #f2f2f2; padding: 20px; text-align: center">
+  <h1>Financial Planner App</h1>
+</div>

--- a/src/common/email/templates/html/sign-up-code.html
+++ b/src/common/email/templates/html/sign-up-code.html
@@ -1,0 +1,8 @@
+<div style="padding: 20px">
+  <p>Olá, :name</p>
+  <p>
+    Aqui está o seu código de verificação: :verificationCode. Tenha em mente de
+    que este código expira em 5 minutos, portanto finalize eu cadastro o quanto
+    antes.
+  </p>
+</div>

--- a/src/common/email/templates/sign-up-code.ts
+++ b/src/common/email/templates/sign-up-code.ts
@@ -1,11 +1,13 @@
 import { TypeToTemplateArgsMap } from '../templates/enums';
+import { getHtmlString } from './utils';
 
 export default (args: TypeToTemplateArgsMap['SIGN_UP_CODE']) => {
-  return `
-  <div class="middle-section" style="padding: 20px">
-    <p>Olá, ${args.name}</p>
-    <p>
-      Aqui está o seu código de verificação: ${args.verificationCode}. Tenha em mente de que este código expira em 5 minutos, portanto finalize eu cadastro o quanto antes.
-    </p>
-  </div>`;
+  const rawTemplate = getHtmlString('sign-up-code.html');
+
+  let fullTemplate = rawTemplate;
+  Object.entries(args).forEach(([key, value]) => {
+    fullTemplate = fullTemplate.replace(`:${key}`, `${value}`);
+  });
+
+  return fullTemplate;
 };

--- a/src/common/email/templates/utils/get-html-string.ts
+++ b/src/common/email/templates/utils/get-html-string.ts
@@ -1,0 +1,8 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export default (htmlFileName: string) => {
+  return fs.readFileSync(path.join(__dirname, '../html', htmlFileName), {
+    encoding: 'utf-8',
+  });
+};

--- a/src/common/email/templates/utils/index.ts
+++ b/src/common/email/templates/utils/index.ts
@@ -1,0 +1,1 @@
+export { default as getHtmlString } from './get-html-string';


### PR DESCRIPTION
# Main changes

- Add utility function to read .html files as strings
- Modify templates to be written as .html files (thus making it easier to create templates and apply inline CSS)
- Modify `nest-cli` to copy .html files as assets on /dist folder