### PR TITLE
chore: add dbeaver cloud container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,9 @@ services:
       - PGDATA=/data/postgres
     volumes:
       - ./data/pg:/data/postgres
+
+  dbeaver-server:
+    container_name: dbeaver-server
+    image: dbeaver/cloudbeaver
+    ports:
+      - 7777:8978


### PR DESCRIPTION
# Main changes

- Add dbeaver cloud container

The idea behind it is to offer an alternative to download a DB management tool, the cloud container is simple but gets the job done.