### PR TITLE
chore: improve types and imports of DTOs/schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "stop": "docker compose down",
     "start:debug": "nest start --debug 0.0.0.0:9229 --watch",
     "start:prod": "node dist/main",
-    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint": "eslint ./src",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/src/common/email/assemble-template.ts
+++ b/src/common/email/assemble-template.ts
@@ -4,6 +4,7 @@ import { getHtmlString } from './templates/utils';
 
 export default function assembleTemplate(
   type: AllTypes,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   templateArgs: any,
 ): { subject: string; html: string } {
   let subject;

--- a/src/common/events/events.service.ts
+++ b/src/common/events/events.service.ts
@@ -1,4 +1,4 @@
-// src/event.service.ts
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Injectable } from '@nestjs/common';
 import { EventEmitter } from 'events';
 

--- a/src/common/exceptions/filters/BadRequestException.filter.ts
+++ b/src/common/exceptions/filters/BadRequestException.filter.ts
@@ -2,7 +2,6 @@ import {
   ExceptionFilter,
   Catch,
   ArgumentsHost,
-  HttpException,
   HttpStatus,
 } from '@nestjs/common';
 import { Response } from 'express';
@@ -19,7 +18,7 @@ interface FormattedException {
 
 @Catch(BadRequestException)
 export default class BadRequestExceptionFilter implements ExceptionFilter {
-  formatException(exception: any, ctx: HttpArgumentsHost) {
+  formatException(exception: BadRequestException, ctx: HttpArgumentsHost) {
     const response = ctx.getResponse<Response>();
     const status = exception.getStatus();
 
@@ -32,7 +31,7 @@ export default class BadRequestExceptionFilter implements ExceptionFilter {
     return response.status(status).json(formattedException);
   }
 
-  catch(exception: HttpException, host: ArgumentsHost) {
+  catch(exception: BadRequestException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const formattedException = this.formatException(exception, ctx);
 

--- a/src/common/exceptions/filters/HttpException.filter.ts
+++ b/src/common/exceptions/filters/HttpException.filter.ts
@@ -6,6 +6,7 @@ import {
   HttpStatus,
   UnauthorizedException,
   ConflictException,
+  Logger,
 } from '@nestjs/common';
 import { Response } from 'express';
 import { HttpArgumentsHost } from '@nestjs/common/interfaces';
@@ -20,7 +21,12 @@ interface FormattedException {
 
 @Catch(HttpException, DatabaseException)
 export default class HttpExceptionFilter implements ExceptionFilter {
-  formatException(exception: any, ctx: HttpArgumentsHost) {
+  private readonly logger = new Logger(HttpExceptionFilter.name);
+
+  formatException(
+    exception: HttpException | DatabaseException,
+    ctx: HttpArgumentsHost,
+  ) {
     const response = ctx.getResponse<Response>();
     const status = exception.getStatus() || HttpStatus.INTERNAL_SERVER_ERROR;
 
@@ -40,14 +46,13 @@ export default class HttpExceptionFilter implements ExceptionFilter {
         exception instanceof ConflictException
       )
     ) {
-      // eslint-disable-next-line no-console
-      console.log(exception);
+      this.logger.error(exception.message, exception.stack);
     }
 
     return response.status(status).json(formattedException);
   }
 
-  catch(exception: HttpException, host: ArgumentsHost) {
+  catch(exception: HttpException | DatabaseException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
     const formattedException = this.formatException(exception, ctx);
 

--- a/src/common/utils/handle-database-call.wrapper.ts
+++ b/src/common/utils/handle-database-call.wrapper.ts
@@ -10,8 +10,8 @@ export default async function handleDatabaseCall<T>(
 ) {
   try {
     return await dbCall;
-  } catch (error: any) {
-    if (errorHandler) errorHandler(error);
-    else throw new DatabaseException(error);
+  } catch (error) {
+    if (errorHandler) errorHandler(error as PrismaException);
+    else throw new DatabaseException(error as PrismaException);
   }
 }

--- a/src/common/validation/payload-validation.interceptor.ts
+++ b/src/common/validation/payload-validation.interceptor.ts
@@ -6,20 +6,20 @@ import {
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { Request } from 'express';
-import { ZodObject } from 'zod';
+import { UnknownKeysParam, ZodObject, ZodRawShape } from 'zod';
 import { BadRequestException } from '../exceptions';
 
 type SchemaContainer = {
-  params?: ZodObject<any, any>;
-  body?: ZodObject<any, any>;
-  query?: ZodObject<any, any>;
+  params?: ZodObject<ZodRawShape, UnknownKeysParam>;
+  body?: ZodObject<ZodRawShape, UnknownKeysParam>;
+  query?: ZodObject<ZodRawShape, UnknownKeysParam>;
 };
 
 @Injectable()
 export class ValidationInterceptor implements NestInterceptor {
   constructor(public validationObject: SchemaContainer) {}
 
-  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const request = context.switchToHttp().getRequest<Request>();
     const { body, params, query } = request;
 
@@ -39,7 +39,10 @@ export class ValidationInterceptor implements NestInterceptor {
     return next.handle();
   }
 
-  validateParams(params: any, paramsSchema: ZodObject<any, any>) {
+  validateParams(
+    params: unknown,
+    paramsSchema: ZodObject<ZodRawShape, UnknownKeysParam>,
+  ) {
     const result = paramsSchema.safeParse(params);
     if (!result.success) {
       throw new BadRequestException(result.error, 'params');
@@ -48,7 +51,10 @@ export class ValidationInterceptor implements NestInterceptor {
     return;
   }
 
-  validateBody(body: any, bodySchema: ZodObject<any, any>) {
+  validateBody(
+    body: unknown,
+    bodySchema: ZodObject<ZodRawShape, UnknownKeysParam>,
+  ) {
     const result = bodySchema.safeParse(body);
 
     if (!result.success) {
@@ -58,7 +64,10 @@ export class ValidationInterceptor implements NestInterceptor {
     return;
   }
 
-  validateQuery(query: any, querySchema: ZodObject<any, any>) {
+  validateQuery(
+    query: unknown,
+    querySchema: ZodObject<ZodRawShape, UnknownKeysParam>,
+  ) {
     const result = querySchema.safeParse(query);
     if (!result.success) {
       throw new BadRequestException(result.error, 'query');

--- a/src/init/init.service.ts
+++ b/src/init/init.service.ts
@@ -17,7 +17,7 @@ export class InitService {
       await this.connectToDatabase();
 
       this.events.emitEvent('ready', this.logger);
-    } catch (error: any) {
+    } catch (error) {
       this.logger.error(
         `Initialization failed: ${error.message}`,
         error.stack,

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -12,7 +12,7 @@ import { ConfigService } from '@nestjs/config';
 import { Request, Response } from 'express';
 
 import { ValidationInterceptor } from 'src/common/validation/payload-validation.interceptor';
-import { SignIn, signInSchema } from './dto/sign-in.dto';
+import { AuthDTOs, default as schemas } from './dto';
 import { AuthService } from './auth.service';
 import { default as enums } from 'src/enums';
 import { RouteDoc } from 'src/common/docs';
@@ -32,9 +32,9 @@ export class AuthController {
   @Post('/login')
   @RouteDoc(docs.login)
   @HttpCode(HttpStatus.OK)
-  @UseInterceptors(new ValidationInterceptor(signInSchema))
+  @UseInterceptors(new ValidationInterceptor(schemas.signIn))
   async signIn(
-    @Body() body: SignIn,
+    @Body() body: AuthDTOs['signIn'],
     @Res({ passthrough: true }) response: Response,
   ) {
     const { access_token, refresh_token } = await this.authService.signIn(body);

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -5,7 +5,7 @@ import { Request } from 'express';
 import * as bcrypt from 'bcrypt';
 
 import { UsersService } from '../users/users.service';
-import { SignIn } from './dto/sign-in.dto';
+import { SignInDTO } from './dto/sign-in.dto';
 import { EnvSchema } from 'src/config';
 
 type Tokens = {
@@ -21,7 +21,7 @@ export class AuthService {
     private config: ConfigService<EnvSchema, true>,
   ) {}
 
-  async signIn({ username, password }: SignIn): Promise<Tokens> {
+  async signIn({ username, password }: SignInDTO): Promise<Tokens> {
     const user = await this.usersService.findOneByEmail({ email: username });
 
     if (!user) {

--- a/src/modules/auth/dto/index.ts
+++ b/src/modules/auth/dto/index.ts
@@ -1,0 +1,9 @@
+import { SignInDTO, signInSchema } from './sign-in.dto';
+
+export type AuthDTOs = {
+  signIn: SignInDTO;
+};
+
+export default {
+  signIn: signInSchema,
+};

--- a/src/modules/auth/dto/sign-in.dto.ts
+++ b/src/modules/auth/dto/sign-in.dto.ts
@@ -7,4 +7,4 @@ export const signInSchema = {
   }),
 };
 
-export type SignIn = zod.infer<typeof signInSchema.body>;
+export type SignInDTO = zod.infer<typeof signInSchema.body>;

--- a/src/modules/users/dto/find-one-by-email.dto.ts
+++ b/src/modules/users/dto/find-one-by-email.dto.ts
@@ -4,6 +4,6 @@ export const findOneUserByEmailSchema = {
   body: zod.object({ email: zod.string() }),
 };
 
-export type FindOneUserByEmail = zod.infer<
+export type FindOneUserByEmailDTO = zod.infer<
   typeof findOneUserByEmailSchema.body
 >;

--- a/src/modules/users/dto/find-one-by-id.dto.ts
+++ b/src/modules/users/dto/find-one-by-id.dto.ts
@@ -4,4 +4,4 @@ export const findOneUserByIdSchema = {
   params: zod.object({ id: zod.string() }),
 };
 
-export type FindOneUserById = zod.infer<typeof findOneUserByIdSchema.params>;
+export type FindOneUserByIdDTO = zod.infer<typeof findOneUserByIdSchema.params>;

--- a/src/modules/users/dto/index.ts
+++ b/src/modules/users/dto/index.ts
@@ -1,0 +1,24 @@
+import { ValidateSignUpDTO, validateSignUpSchema } from './validate-sign-up';
+import { createUserDtoSchema, CreateUserDto } from './create.dto';
+import {
+  FindOneUserByEmailDTO,
+  findOneUserByEmailSchema,
+} from './find-one-by-email.dto';
+import {
+  FindOneUserByIdDTO,
+  findOneUserByIdSchema,
+} from './find-one-by-id.dto';
+
+export type UserDTOs = {
+  findOneByEmail: FindOneUserByEmailDTO;
+  validateSignUp: ValidateSignUpDTO;
+  findOneById: FindOneUserByIdDTO;
+  createUser: CreateUserDto;
+};
+
+export default {
+  findOneByEmail: findOneUserByEmailSchema,
+  validateSignUp: validateSignUpSchema,
+  findOneById: findOneUserByIdSchema,
+  createUser: createUserDtoSchema,
+};

--- a/src/modules/users/dto/validate-sign-up.ts
+++ b/src/modules/users/dto/validate-sign-up.ts
@@ -4,4 +4,4 @@ export const validateSignUpSchema = {
   body: zod.object({ email: zod.string().email(), code: zod.string() }),
 };
 
-export type ValidateSignUp = zod.infer<typeof validateSignUpSchema.body>;
+export type ValidateSignUpDTO = zod.infer<typeof validateSignUpSchema.body>;

--- a/src/modules/users/entities/user.entity.ts
+++ b/src/modules/users/entities/user.entity.ts
@@ -1,1 +1,21 @@
-export class User {}
+import { User as UserModel } from '@prisma/client';
+
+/* 
+  The intended use for this class is to just pass a return type to key functions (such as findOne),
+  and so it does not need its properties initialized in a constructor or anything, that's why the
+  definite assignment symbol is being used as a way to suppress typescript errors.
+
+  Again, this class is NOT intended to be used in any way other than offering a type.
+*/
+
+export class User implements UserModel {
+  id!: string;
+  name!: string;
+  email!: string;
+  password!: string;
+  userTypeId!: number;
+  verified!: boolean;
+  createdAt!: Date;
+  updatedAt!: Date | null;
+  deletedAt!: Date | null;
+}

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -8,14 +8,11 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
-import { UsersService } from './users.service';
-import { createUserDtoSchema, CreateUserDto } from './dto/create.dto';
+
 import { ValidationInterceptor } from 'src/common/validation/payload-validation.interceptor';
-import {
-  FindOneUserById,
-  findOneUserByIdSchema,
-} from './dto/find-one-by-id.dto';
-import { ValidateSignUp, validateSignUpSchema } from './dto/validate-sign-up';
+import { UserDTOs, default as schemas } from './dto';
+import { UsersService } from './users.service';
+import { User } from './entities/user.entity';
 import { RouteDoc } from 'src/common/docs';
 import * as userDocs from './docs';
 
@@ -26,24 +23,28 @@ export class UsersController {
   @Post('/sign-up')
   @HttpCode(HttpStatus.CREATED)
   @RouteDoc(userDocs.signUp)
-  @UseInterceptors(new ValidationInterceptor(createUserDtoSchema))
-  async create(@Body() user: CreateUserDto): Promise<void> {
+  @UseInterceptors(new ValidationInterceptor(schemas.createUser))
+  async create(@Body() user: UserDTOs['createUser']): Promise<void> {
     await this.usersService.create(user);
   }
 
   @Post('/validate-sign-up')
   @HttpCode(HttpStatus.OK)
   @RouteDoc(userDocs.validateSignUp)
-  @UseInterceptors(new ValidationInterceptor(validateSignUpSchema))
-  async validateSignUp(@Body() signUpInfo: ValidateSignUp) {
+  @UseInterceptors(new ValidationInterceptor(schemas.validateSignUp))
+  async validateSignUp(
+    @Body() signUpInfo: UserDTOs['validateSignUp'],
+  ): Promise<void> {
     await this.usersService.validateSignUp(signUpInfo);
   }
 
   @Get('/:id')
   @HttpCode(HttpStatus.OK)
   @RouteDoc(userDocs.findOne)
-  @UseInterceptors(new ValidationInterceptor(findOneUserByIdSchema))
-  async findOne(@Param() params: FindOneUserById): Promise<any> {
+  @UseInterceptors(new ValidationInterceptor(schemas.findOneById))
+  async findOne(
+    @Param() params: UserDTOs['findOneById'],
+  ): Promise<Partial<User>> {
     return await this.usersService.findOneById({ id: params.id });
   }
 }

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -11,22 +11,19 @@ import * as bcrypt from 'bcrypt';
 import { DateTime } from 'luxon';
 
 import { PrismaService } from 'src/common/database/prisma/prisma.service';
+import errorCodes from 'src/common/database/prisma/error-codes';
+import { EmailService } from 'src/common/email/email.service';
+import errorTypes from 'src/common/exceptions/error-types';
+import { handleDatabaseCall } from 'src/common/utils';
+import { User } from './entities/user.entity';
+import { UserDTOs } from './dto';
 import {
   BaseException,
   UnprocessableEntityException,
 } from 'src/common/exceptions';
-import { EmailService } from 'src/common/email/email.service';
-import errorTypes from 'src/common/exceptions/error-types';
-import { ValidateSignUp } from './dto/validate-sign-up';
-import { handleDatabaseCall } from 'src/common/utils';
-import { CreateUserDto } from './dto/create.dto';
-import { FindOneUserById } from './dto/find-one-by-id.dto';
-import { FindOneUserByEmail } from './dto/find-one-by-email.dto';
 import DatabaseException, {
   PrismaException,
 } from 'src/common/exceptions/Database.exception';
-
-import errorCodes from 'src/common/database/prisma/error-codes';
 
 @Injectable()
 export class UsersService {
@@ -36,7 +33,7 @@ export class UsersService {
     private database: PrismaService,
   ) {}
 
-  async create(user: CreateUserDto) {
+  async create(user: UserDTOs['createUser']): Promise<void> {
     const existingVerificationCodes = await handleDatabaseCall(
       this.database.signUpVerificationCode.findMany({
         where: {
@@ -120,14 +117,12 @@ export class UsersService {
         name: user.name,
         verificationCode: signUpVerificationCode,
       });
-    } catch (error: any) {
+    } catch (error) {
       throw new BaseException(error.message);
     }
-
-    return;
   }
 
-  async validateSignUp(signUpInfo: ValidateSignUp) {
+  async validateSignUp(signUpInfo: UserDTOs['validateSignUp']): Promise<void> {
     const signUpVerificationCode = await handleDatabaseCall(
       this.database.signUpVerificationCode.findFirst({
         where: {
@@ -167,7 +162,7 @@ export class UsersService {
     }
   }
 
-  async findOneById(payload: FindOneUserById) {
+  async findOneById(payload: UserDTOs['findOneById']): Promise<Partial<User>> {
     const desiredParameters = ['name', 'email', 'userTypeId'];
     const selectObject: Record<string, boolean> = {};
     desiredParameters.forEach((param) => {
@@ -189,7 +184,9 @@ export class UsersService {
   }
 
   // Used by Auth
-  async findOneByEmail(payload: FindOneUserByEmail) {
+  async findOneByEmail(
+    payload: UserDTOs['findOneByEmail'],
+  ): Promise<User | null> {
     const user = await handleDatabaseCall(
       this.database.user.findUnique({
         where: { email: payload.email },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "strictBindCallApply": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "strict": true
+    "strict": true,
+    "useUnknownInCatchVariables": false
   }
 }


### PR DESCRIPTION
# Main changes

- [X] improve types to reduce number of ANYs
- [X] refactor imports of DTOs and schemas on controllers
- [X] reduce scope of lint script to /src
- [X] modify `tsconfig.json` to not presume type `unknown` for errors on catch() blocks

# Type improvement

There was a significant amount of any types (around 25) caused by catch() blocks and other super generic classes (such as interceptors). The amount has been greatly reduced, but there are some instances (such as email's template args) that proved themselves quite the challenge to improve. Future efforts can be applied towards improving these key classes and args but, for the moment the refactors in this PR already suffice the need of better types.

# User Entity

The user entity has been defined as a class that implements the Prisma User model. SInce the entity's only intended use is to provide a type to be returned, the class does not have a constructor or its properties "correctly initialized". The definition of this class as it is now offers better control over the types on the FindOneById controller. The structure of the user will likely change in the future, just a side note...