### PR TITLE
feat: database UUIDs are now encrypted on the endpoints' responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,14 @@
+# App generals
 NODE_ENV=development
 API_DOMAIN=localhost
 API_PORT=4000
 ALLOWED_ORIGINS=http://localhost:3000
 ACCESS_TOKEN_EXPIRATION_TIME=5m
 REFRESH_TOKEN_EXPIRATION_TIME=10m
+
+# Encryption
+UUID_CIPHER_ALGORITHM=something
+UUID_CIPHER_KEY=somethingElse
 
 # SMTP Config
 SMTP_HOST=smtp.gmail.com

--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ Convert them to base64 and put the converted values in the .env
 `base64 -w 0 public_key.pem`
 
 The .pem files can be deleted afterward.
+
+## How to generate cipher secret
+
+Execute the following command on the terminal:
+
+`node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`
+
+This should print a 64 characters long hex string that can be used with for example a `aes-256-cbc` algorithm. Please note that you can change the algorithm through an environment variable, but mind the necessary changes to the key size (also a .env variable), IV size requirements and more.

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
+        "uuid": "^11.1.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -2800,6 +2801,19 @@
         "rxjs": "^7.1.0"
       }
     },
+    "node_modules/@nestjs/config/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@nestjs/core": {
       "version": "10.4.15",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.4.15.tgz",
@@ -3462,6 +3476,19 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@smithy/middleware-serde": {
@@ -11424,15 +11451,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
+    "uuid": "^11.1.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/common/cipher/cipher.module.ts
+++ b/src/common/cipher/cipher.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { CipherService } from './cipher.service';
+
+@Module({
+  providers: [CipherService],
+  exports: [CipherService],
+})
+export class CipherModule {}

--- a/src/common/cipher/cipher.service.ts
+++ b/src/common/cipher/cipher.service.ts
@@ -1,0 +1,59 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+import { validate as isValidUUid } from 'uuid';
+import { Injectable } from '@nestjs/common';
+
+import { ConfigService } from '@nestjs/config';
+import { BaseException } from '../exceptions';
+import { EnvSchema } from '../../config';
+
+@Injectable()
+export class CipherService {
+  private readonly key: Buffer;
+  private readonly algorithm;
+
+  constructor(private config: ConfigService<EnvSchema, true>) {
+    this.algorithm = config.get('UUID_CIPHER_ALGORITHM');
+    const keyHex = config.get('UUID_CIPHER_KEY');
+
+    this.key = Buffer.from(keyHex, 'hex');
+  }
+
+  encryptUUID(uuid: string): string {
+    if (!isValidUUid(uuid)) {
+      throw new BaseException('Invalid UUID');
+    }
+
+    const iv = randomBytes(16);
+    const cipher = createCipheriv(this.algorithm, this.key, iv);
+    const encrypted = Buffer.concat([cipher.update(uuid, 'utf8'), cipher.final()]);
+
+    const combined = Buffer.concat([iv, encrypted]);
+    return toBase64Url(combined);
+  }
+
+  decryptUUID(base64url: string): string | null {
+    try {
+      const combined = fromBase64Url(base64url);
+      const iv = combined.subarray(0, 16);
+      const encrypted = combined.subarray(16);
+
+      const decipher = createDecipheriv(this.algorithm, this.key, iv);
+      const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+
+      return decrypted.toString('utf8');
+    } catch {
+      return null;
+    }
+  }
+}
+
+/* The functions below iam to make the end result URL safe, meaning no +, / or = characters that could interfere with the URL parsing */
+function toBase64Url(buffer: Buffer): string {
+  return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function fromBase64Url(base64url: string): Buffer {
+  let base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+  while (base64.length % 4 !== 0) base64 += '=';
+  return Buffer.from(base64, 'base64');
+}

--- a/src/common/database/prisma/prisma.service.ts
+++ b/src/common/database/prisma/prisma.service.ts
@@ -14,4 +14,8 @@ export class PrismaService extends PrismaClient implements OnApplicationShutdown
     this.logger.warn(`Received ${signal} signal. Disconnecting from database...`);
     return this.$disconnect();
   }
+
+  createSelectObject<T extends string>(fields: readonly T[]) {
+    return Object.fromEntries(fields.map((key) => [key, true])) as Record<T, true>;
+  }
 }

--- a/src/common/exceptions/filters/BadRequestException.filter.ts
+++ b/src/common/exceptions/filters/BadRequestException.filter.ts
@@ -21,6 +21,7 @@ export default class BadRequestExceptionFilter implements ExceptionFilter {
       statusCode: status,
       timestamp: new Date().toISOString(),
       validationIssues: [...exception.validationIssues],
+      message: exception.message ? exception.message : undefined,
     };
 
     return response.status(status).json(formattedException);

--- a/src/common/validation/decrypt-uuid.pipe.ts
+++ b/src/common/validation/decrypt-uuid.pipe.ts
@@ -1,0 +1,24 @@
+import { Injectable, PipeTransform } from '@nestjs/common';
+import { CipherService } from '../cipher/cipher.service';
+import BadRequestException from '../exceptions/BadRequest.exception';
+import { validate as isValidUUid } from 'uuid';
+
+@Injectable()
+export default class DecryptUUIDPipe implements PipeTransform {
+  constructor(private readonly cipher: CipherService) {}
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  transform(data: any): any {
+    const decrypted = this.cipher.decryptUUID(data.id);
+
+    if (!decrypted || !isValidUUid(decrypted)) {
+      throw new BadRequestException('Invalid ID', 'params');
+    }
+
+    /*
+      This will substitute the encrypted UUID for the raw, thus avoiding having to call the decrypt function in every controller
+    */
+    data.id = decrypted;
+    return data;
+  }
+}

--- a/src/common/validation/index.ts
+++ b/src/common/validation/index.ts
@@ -1,0 +1,1 @@
+export { default as DecryptUUIDPipe } from './decrypt-uuid.pipe';

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,7 @@
 import { z as zod } from 'zod';
+import { getCiphers } from 'crypto';
+
+const cryptoCiphers = getCiphers();
 
 export const envSchema = zod.object({
   NODE_ENV: zod.string(),
@@ -7,6 +10,12 @@ export const envSchema = zod.object({
   ALLOWED_ORIGINS: zod.string(),
   ACCESS_TOKEN_EXPIRATION_TIME: zod.string(),
   REFRESH_TOKEN_EXPIRATION_TIME: zod.string(),
+
+  // Encryption
+  UUID_CIPHER_ALGORITHM: zod.union(
+    cryptoCiphers.map((name) => zod.literal(name)) as [zod.ZodLiteral<string>, zod.ZodLiteral<string[]>],
+  ),
+  UUID_CIPHER_KEY: zod.string().length(64, 'Invalid cipher secret (must be 64 hex chars)'),
 
   // SMTP Config
   SMTP_HOST: zod.string(),

--- a/src/modules/attachment/attachment.controller.ts
+++ b/src/modules/attachment/attachment.controller.ts
@@ -5,6 +5,7 @@ import { AttachmentDTOs, default as schemas } from './dto';
 import { AttachmentService } from './attachment.service';
 import { JWTAuthGuard } from '../auth/guards';
 import { AuthenticatedRequest } from '../auth/dto';
+import { DecryptUUIDPipe } from '../../common/validation';
 
 @Controller('attachments')
 export class AttachmentController {
@@ -24,7 +25,7 @@ export class AttachmentController {
   @UseGuards(JWTAuthGuard)
   @UseInterceptors(new ValidationInterceptor(schemas.download))
   @HttpCode(HttpStatus.OK)
-  download(@Req() req: AuthenticatedRequest, @Param() params: AttachmentDTOs['download']) {
+  download(@Req() req: AuthenticatedRequest, @Param(DecryptUUIDPipe) params: AttachmentDTOs['download']) {
     return this.attachmentService.download(params.id, req.user);
   }
 
@@ -32,7 +33,7 @@ export class AttachmentController {
   @UseGuards(JWTAuthGuard)
   @UseInterceptors(new ValidationInterceptor(schemas.delete))
   @HttpCode(HttpStatus.NO_CONTENT)
-  delete(@Req() req: AuthenticatedRequest, @Param() params: AttachmentDTOs['delete']) {
+  delete(@Req() req: AuthenticatedRequest, @Param(DecryptUUIDPipe) params: AttachmentDTOs['delete']) {
     return this.attachmentService.delete(params.id, req.user);
   }
 }

--- a/src/modules/attachment/attachment.module.ts
+++ b/src/modules/attachment/attachment.module.ts
@@ -3,10 +3,12 @@ import { AttachmentService } from './attachment.service';
 import { AttachmentController } from './attachment.controller';
 import { S3Service } from '../../common/aws/S3/s3.service';
 import { PrismaService } from '../../common/database/prisma/prisma.service';
+import { CipherModule } from '../../common/cipher/cipher.module';
 
 @Module({
   controllers: [AttachmentController],
   providers: [AttachmentService, S3Service, PrismaService],
   exports: [AttachmentService],
+  imports: [CipherModule],
 })
 export class AttachmentModule {}

--- a/src/modules/attachment/attachment.service.ts
+++ b/src/modules/attachment/attachment.service.ts
@@ -9,6 +9,7 @@ import { CreateAttachmentResponseDTO } from './dto/create.response.dto';
 import { SignedInUserDTO } from '../auth/dto/signed-in-user.dto';
 import { handleDatabaseCall, isDatabaseException } from '../../common/utils';
 import { PrismaService } from '../../common/database/prisma/prisma.service';
+import { CipherService } from '../../common/cipher/cipher.service';
 
 @Injectable()
 export class AttachmentService {
@@ -16,6 +17,7 @@ export class AttachmentService {
     private S3Service: S3Service,
     private database: PrismaService,
     private config: ConfigService<EnvSchema, true>,
+    private cipherService: CipherService,
   ) {}
 
   async create(files: AttachmentDTOs['create']['files'], user: SignedInUserDTO): Promise<AttachmentResponseDTOs['create'][]> {
@@ -51,7 +53,7 @@ export class AttachmentService {
         else throw error;
       }
 
-      return { id: uploadedFile!.id, key };
+      return { id: this.cipherService.encryptUUID(uploadedFile!.id), key };
     });
 
     const results = await Promise.allSettled(promises);

--- a/src/modules/attachment/dto/delete.dto.ts
+++ b/src/modules/attachment/dto/delete.dto.ts
@@ -2,7 +2,7 @@ import { z as zod } from 'zod';
 
 export const deleteAttachmentSchema = {
   params: zod.object({
-    id: zod.string().uuid(),
+    id: zod.string(),
   }),
 };
 

--- a/src/modules/attachment/dto/download.dto.ts
+++ b/src/modules/attachment/dto/download.dto.ts
@@ -2,7 +2,7 @@ import { z as zod } from 'zod';
 
 export const downloadAttachmentSchema = {
   params: zod.object({
-    id: zod.string().uuid(),
+    id: zod.string(),
   }),
 };
 

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -8,12 +8,14 @@ import { ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './strategies';
 import { EnvSchema } from 'src/config';
+import { PrismaModule } from '../../common/database/prisma/prisma.module';
 
 @Module({
   providers: [AuthService, JwtStrategy],
   controllers: [AuthController],
   exports: [AuthService],
   imports: [
+    PrismaModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     UsersModule,
     JwtModule.registerAsync({

--- a/src/modules/auth/dto/signed-in-user.dto.ts
+++ b/src/modules/auth/dto/signed-in-user.dto.ts
@@ -1,4 +1,5 @@
 export type SignedInUserDTO = {
+  id: string;
   name: string;
   email: string;
   accountId: string;

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -3,10 +3,10 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
 
-import { UsersService } from 'src/modules/users/users.service';
 import { EnvSchema } from 'src/config';
 import { Request } from 'express';
 import { z as zod } from 'zod';
+import { PrismaService } from '../../../common/database/prisma/prisma.service';
 
 const tokenSchema = zod.object({
   sub: zod.string().uuid(),
@@ -23,7 +23,7 @@ export type TokenSchema = zod.infer<typeof tokenSchema>;
 export default class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(
     private config: ConfigService<EnvSchema, true>,
-    private usersService: UsersService,
+    private database: PrismaService,
   ) {
     const publicKey = config.get('JWT_PUBLIC_KEY', { infer: true });
 
@@ -50,7 +50,10 @@ export default class JwtStrategy extends PassportStrategy(Strategy) {
 
     if (!isTokenValid) throw new UnauthorizedException();
 
-    const user = await this.usersService.findOneById({ id: payload.sub });
+    const user = await this.database.user.findUnique({
+      where: { id: payload.sub },
+      select: this.database.createSelectObject(['id', 'name', 'email', 'accountId', 'createdAt']),
+    });
 
     if (!user) throw new UnauthorizedException();
 

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -3,11 +3,12 @@ import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { EmailModule } from 'src/common/email/email.module';
 import { PrismaService } from 'src/common/database/prisma/prisma.service';
+import { CipherModule } from '../../common/cipher/cipher.module';
 
 @Module({
   controllers: [UsersController],
   providers: [UsersService, PrismaService],
-  imports: [EmailModule],
+  imports: [EmailModule, CipherModule],
   exports: [UsersService],
 })
 export class UsersModule {}

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -9,6 +9,7 @@ import { DateTime } from 'luxon';
 import DatabaseException, { PrismaException } from 'src/common/exceptions/Database.exception';
 import { BaseException, UnprocessableEntityException } from 'src/common/exceptions';
 import { PrismaService } from 'src/common/database/prisma/prisma.service';
+import { CipherService } from '../../common/cipher/cipher.service';
 import errorCodes from 'src/common/database/prisma/error-codes';
 import { EmailService } from 'src/common/email/email.service';
 import errorTypes from 'src/common/exceptions/error-types';
@@ -22,6 +23,7 @@ export class UsersService {
     private emailService: EmailService,
     private config: ConfigService<EnvSchema, true>,
     private database: PrismaService,
+    private cipherService: CipherService,
   ) {}
 
   async create(user: UserDTOs['createUser']): Promise<void> {
@@ -142,16 +144,10 @@ export class UsersService {
   }
 
   async findOneById(payload: UserDTOs['findOneById']): Promise<Partial<User>> {
-    const desiredParameters = ['name', 'email', 'accountId', 'createdAt'];
-    const selectObject: Record<string, boolean> = {};
-    desiredParameters.forEach((param) => {
-      selectObject[param] = true;
-    });
-
     const user = await handleDatabaseCall(
       this.database.user.findUnique({
         where: { id: payload.id, verified: true },
-        select: selectObject,
+        select: this.database.createSelectObject(['id', 'name', 'email', 'accountId', 'createdAt']),
       }),
     );
 
@@ -159,7 +155,11 @@ export class UsersService {
       throw new NotFoundException();
     }
 
-    return user;
+    return {
+      ...user,
+      id: this.cipherService.encryptUUID(user.id),
+      accountId: this.cipherService.encryptUUID(user.accountId),
+    };
   }
 
   // Used by Auth


### PR DESCRIPTION
## Main changes

- [X] create cipher module and service for UUID encryption
- [X] implement cipher module on key routes

The main purpose behind the cipher module is to hide the original database UUIDs when returning them to the client. In order to do that, they are encrypted using a given algorithm and key (both securely hidden in the .env file) through the `crypto` module.

Each time the encryption is performed a different end-result is produced, because the cipher service using a randomly generated IV value for every encryption, which improves security. Since the IV is concatenated in the end-result, the decryption will always work, because we extract the necessary values from the resource ID to revert it back to an UUID.

The only downside is a quite big resource ID, but given the security it provides is a small trade-off.

## Other changes

- [X] create utility function to create select objects for prisma queries
- [X] remove use of `findOneById` from JWT strategy and make a dedicated query (allowing both to have different returns)