### PR TITLE
docs: document missing routes

### DIFF
--- a/src/common/docs/error-templates.ts
+++ b/src/common/docs/error-templates.ts
@@ -5,22 +5,8 @@ export default Object.seal({
     status: HttpStatus.INTERNAL_SERVER_ERROR,
     description: 'Internal Server Error',
     schema: {
-      type: 'object',
-      properties: {
-        statusCode: {
-          type: 'number',
-          example: HttpStatus.INTERNAL_SERVER_ERROR,
-        },
-        timestamp: {
-          type: 'Date',
-          example: '2024-08-25T15:52:11.260Z',
-        },
-        message: {
-          type: 'string',
-          example: 'The error message here',
-          optional: true,
-        },
-      },
+      type: 'text',
+      example: 'Internal Server Error',
     },
   },
 
@@ -40,7 +26,7 @@ export default Object.seal({
         },
         message: {
           type: 'string',
-          example: 'Invalid Credentials',
+          example: 'Unauthorized',
         },
       },
     },
@@ -109,6 +95,67 @@ export default Object.seal({
         message: {
           type: 'string',
           example: 'There is already an user registered with the provided email address',
+        },
+      },
+    },
+  },
+
+  [HttpStatus.BAD_REQUEST]: {
+    status: HttpStatus.BAD_REQUEST,
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: {
+          type: 'number',
+          example: HttpStatus.UNPROCESSABLE_ENTITY,
+        },
+        timestamp: {
+          type: 'Date',
+          example: '2024-08-25T15:52:11.260Z',
+        },
+        validationIssues: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              message: {
+                type: 'string',
+                example: 'A string value appears to be incorrect',
+              },
+              path: {
+                type: 'array',
+                description: 'The path to the property with the error. Empty when "nonAllowedKeys" is filled',
+                items: {
+                  anyOf: [{ type: 'string' }, { type: 'number' }],
+                },
+                example: ['files', 0, 'mimeType'],
+              },
+              nonAllowedKeys: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  description: 'Array of non-allowed keys sent in the request',
+                  example: 'accountDeletedAt',
+                },
+              },
+              code: {
+                type: 'string',
+                example: 'unrecognized_keys',
+              },
+              location: {
+                type: 'string',
+                description:
+                  'The location of the property that generated the validation issue. Possible values are: <br><br>' +
+                  'body, query or params',
+                example: 'body',
+              },
+            },
+          },
+        },
+        message: {
+          type: 'string',
+          description: 'The error message. Only present if "validationIssues" is empty',
+          example: 'Invalid ID',
         },
       },
     },

--- a/src/common/docs/route-doc.ts
+++ b/src/common/docs/route-doc.ts
@@ -1,23 +1,30 @@
 import { applyDecorators } from '@nestjs/common';
 import {
-  ApiOperation,
-  ApiResponse,
   ApiBody,
-  ApiParam,
-  ApiQuery,
-  ApiResponseOptions,
   ApiBodyOptions,
-  ApiParamOptions,
-  ApiQueryOptions,
+  ApiConsumes,
+  ApiCookieAuth,
   ApiHeader,
   ApiHeaderOptions,
+  ApiOperation,
+  ApiParam,
+  ApiParamOptions,
+  ApiQuery,
+  ApiQueryOptions,
+  ApiResponse,
+  ApiResponseOptions,
 } from '@nestjs/swagger';
+
+type RequestBodyOptions = ApiBodyOptions & { contentType?: string };
 
 export type ApiDocumentationOptions = {
   summary: string;
   description: string;
   tag: string[];
-  requestBody?: ApiBodyOptions;
+  auth?: {
+    cookie?: boolean;
+  };
+  requestBody?: RequestBodyOptions;
   responses?: Array<ApiResponseOptions>;
   params?: Array<ApiParamOptions>;
   queries?: Array<ApiQueryOptions>;
@@ -35,8 +42,14 @@ export default (options: ApiDocumentationOptions) => {
     }),
   );
 
+  if (options.auth) {
+    if (options.auth.cookie) {
+      decorators.push(ApiCookieAuth());
+    }
+  }
+
   if (options.requestBody) {
-    decorators.push(ApiBody({ ...options.requestBody }));
+    decorators.push(ApiBody({ ...options.requestBody }), ApiConsumes(options.requestBody.contentType || 'application/json'));
   }
 
   if (options.responses) {

--- a/src/common/exceptions/BadRequest.exception.ts
+++ b/src/common/exceptions/BadRequest.exception.ts
@@ -8,16 +8,16 @@ type ErrorLocation = 'body' | 'query' | 'params';
 interface validationIssue {
   code: string;
   path: (string | number)[];
-  properties: (string | number)[];
+  nonAllowedKeys: string[];
   message: string;
-  location: ErrorLocation;
+  location?: ErrorLocation;
 }
 
 export default class BadRequestException extends HttpException {
   name: string;
   validationIssues: validationIssue[] = [];
 
-  constructor(error: ZodError | string, location: ErrorLocation) {
+  constructor(error: ZodError | string, location?: ErrorLocation) {
     super(typeof error === 'string' ? error : error.message, HttpStatus.BAD_REQUEST);
 
     this.name = 'BadRequestException';
@@ -27,13 +27,13 @@ export default class BadRequestException extends HttpException {
         const issueObject: validationIssue = {
           message: errorMessages[issue.code],
           path: [],
-          properties: [],
+          nonAllowedKeys: [],
           code: issue.code,
           location,
         };
 
         if (issue.code === errorCodes.UNRECOGNIZED_KEYS) {
-          issue.keys.forEach((key) => issueObject['properties'].push(key));
+          issue.keys.forEach((key) => issueObject['nonAllowedKeys'].push(key));
         } else {
           issue.path.forEach((value) => issueObject['path'].push(value));
         }

--- a/src/common/exceptions/filters/BadRequestException.filter.ts
+++ b/src/common/exceptions/filters/BadRequestException.filter.ts
@@ -16,12 +16,13 @@ export default class BadRequestExceptionFilter implements ExceptionFilter {
   formatException(exception: BadRequestException, ctx: HttpArgumentsHost) {
     const response = ctx.getResponse<Response>();
     const status = exception.getStatus();
+    const hasValidationIssues = exception.validationIssues && exception.validationIssues.length > 0;
 
     const formattedException: FormattedException = {
       statusCode: status,
       timestamp: new Date().toISOString(),
       validationIssues: [...exception.validationIssues],
-      message: exception.message ? exception.message : undefined,
+      message: hasValidationIssues ? undefined : exception.message,
     };
 
     return response.status(status).json(formattedException);

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,12 @@ async function bootstrap() {
     .setTitle('Nestjs backend API')
     .setDescription('The Nestjs backend API description')
     .setVersion('1.0')
+    .addCookieAuth('access_token', {
+      type: 'apiKey',
+      description: 'The access token required to access private routes',
+      in: 'cookie',
+      name: 'access_token',
+    })
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document);

--- a/src/modules/attachment/attachment.controller.ts
+++ b/src/modules/attachment/attachment.controller.ts
@@ -6,6 +6,8 @@ import { AttachmentService } from './attachment.service';
 import { JWTAuthGuard } from '../auth/guards';
 import { AuthenticatedRequest } from '../auth/dto';
 import { DecryptUUIDPipe } from '../../common/validation';
+import * as attachmentDocs from './docs';
+import { RouteDoc } from '../../common/docs';
 
 @Controller('attachments')
 export class AttachmentController {
@@ -13,6 +15,7 @@ export class AttachmentController {
 
   @Post('/')
   @UseGuards(JWTAuthGuard)
+  @RouteDoc(attachmentDocs.createAttachment)
   @UseInterceptors(new AttachmentInterceptor({ maxFileSizeInBytes: 2 * 1024 * 1024 }), new ValidationInterceptor(schemas.create))
   @HttpCode(HttpStatus.CREATED)
   create(@Req() req: AuthenticatedRequest) {
@@ -23,6 +26,7 @@ export class AttachmentController {
 
   @Get('/:id')
   @UseGuards(JWTAuthGuard)
+  @RouteDoc(attachmentDocs.downloadAttachment)
   @UseInterceptors(new ValidationInterceptor(schemas.download))
   @HttpCode(HttpStatus.OK)
   download(@Req() req: AuthenticatedRequest, @Param(DecryptUUIDPipe) params: AttachmentDTOs['download']) {
@@ -31,6 +35,7 @@ export class AttachmentController {
 
   @Delete('/:id')
   @UseGuards(JWTAuthGuard)
+  @RouteDoc(attachmentDocs.deleteAttachment)
   @UseInterceptors(new ValidationInterceptor(schemas.delete))
   @HttpCode(HttpStatus.NO_CONTENT)
   delete(@Req() req: AuthenticatedRequest, @Param(DecryptUUIDPipe) params: AttachmentDTOs['delete']) {

--- a/src/modules/attachment/attachment.service.ts
+++ b/src/modules/attachment/attachment.service.ts
@@ -53,7 +53,7 @@ export class AttachmentService {
         else throw error;
       }
 
-      return { id: this.cipherService.encryptUUID(uploadedFile!.id), key };
+      return { id: this.cipherService.encryptUUID(uploadedFile!.id), key: this.cipherService.encryptUUID(key) };
     });
 
     const results = await Promise.allSettled(promises);

--- a/src/modules/attachment/docs.ts
+++ b/src/modules/attachment/docs.ts
@@ -1,0 +1,138 @@
+import { ApiDocumentationOptions } from '../../common/docs/route-doc';
+import { errorTemplates } from '../../common/docs';
+import { HttpStatus } from '@nestjs/common';
+
+export const createAttachment: ApiDocumentationOptions = {
+  tag: ['Attachment'],
+  summary: 'Uploads one or more files as multipart/form-data',
+  description: 'Uploads one or more files as multipart/form-data. Files are limited to 2Mb in size per file.',
+  auth: {
+    cookie: true,
+  },
+  requestBody: {
+    contentType: 'multipart/form-data',
+    schema: {
+      type: 'object',
+      properties: {
+        files: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  },
+  responses: [
+    {
+      status: HttpStatus.CREATED,
+      description: 'One or more uploaded file details',
+      schema: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            description: 'Encrypted attachment ID',
+            example: 'xyi9aMl7DFmlO4iMF9dprCvgBNuZx_QwZO5kw0QdsJEb_ocfpeA2bZDIDW65LSkX9u5QvGkbQ4-IrFLStKIgJw',
+          },
+          key: {
+            type: 'string',
+            description: 'Encrypted attachment ID key',
+            example: 'zyi8aMl7DFmlO4iMF9dprCvgBNuZx_QwZO5kw0QdsJEb_pqzpeA2bZFBDW82LSkX9u5QvGkbQ4-IrFLStKIgJf',
+          },
+        },
+      },
+    },
+    {
+      ...errorTemplates[HttpStatus.BAD_REQUEST],
+    },
+    {
+      ...errorTemplates[HttpStatus.UNAUTHORIZED],
+    },
+    {
+      ...errorTemplates[HttpStatus.UNPROCESSABLE_ENTITY],
+      description:
+        'Possible error types:<br><br>' +
+        '`attachments.create.file_size_limit_exceeded` - Happens when one or more attachments have exceeded the file size limit',
+    },
+    {
+      ...errorTemplates[HttpStatus.INTERNAL_SERVER_ERROR],
+    },
+  ],
+};
+
+export const downloadAttachment: ApiDocumentationOptions = {
+  tag: ['Attachment'],
+  summary: 'Downloads an attachment',
+  description: 'Returns the pre-signed url to allow the attachment download',
+  params: [
+    {
+      name: 'id',
+      example: 'xyi9aMl7DFmlO4iMF9dprCvgBNuZx_QwZO5kw0QdsJEb_ocfpeA2bZDIDW65LSkX9u5QvGkbQ4-IrFLStKIgJw',
+      required: true,
+    },
+  ],
+  auth: {
+    cookie: true,
+  },
+  responses: [
+    {
+      status: HttpStatus.OK,
+      description: 'The url to download the attachment, signed with a pre-defined expiration time.',
+      schema: {
+        type: 'object',
+        properties: {
+          url: {
+            type: 'string',
+            description: 'The url to download the attachment',
+            example: 'https://theAwsPreSignedUrlHere.com',
+          },
+        },
+      },
+    },
+    {
+      ...errorTemplates[HttpStatus.BAD_REQUEST],
+    },
+    {
+      ...errorTemplates[HttpStatus.UNAUTHORIZED],
+    },
+    {
+      ...errorTemplates[HttpStatus.NOT_FOUND],
+    },
+    {
+      ...errorTemplates[HttpStatus.INTERNAL_SERVER_ERROR],
+    },
+  ],
+};
+
+export const deleteAttachment: ApiDocumentationOptions = {
+  tag: ['Attachment'],
+  summary: 'Deletes an attachment',
+  description: 'Deletes an attachment',
+  params: [
+    {
+      name: 'id',
+      example: 'xyi9aMl7DFmlO4iMF9dprCvgBNuZx_QwZO5kw0QdsJEb_ocfpeA2bZDIDW65LSkX9u5QvGkbQ4-IrFLStKIgJw',
+      required: true,
+    },
+  ],
+  auth: {
+    cookie: true,
+  },
+  responses: [
+    {
+      status: HttpStatus.NO_CONTENT,
+      description: 'The deletion has been successful',
+    },
+    {
+      ...errorTemplates[HttpStatus.BAD_REQUEST],
+    },
+    {
+      ...errorTemplates[HttpStatus.UNAUTHORIZED],
+    },
+    {
+      ...errorTemplates[HttpStatus.NOT_FOUND],
+    },
+    {
+      ...errorTemplates[HttpStatus.INTERNAL_SERVER_ERROR],
+    },
+  ],
+};

--- a/src/modules/auth/docs.ts
+++ b/src/modules/auth/docs.ts
@@ -5,8 +5,7 @@ import { HttpStatus } from '@nestjs/common';
 export const login: ApiDocumentationOptions = {
   tag: ['Auth'],
   summary: 'Endpoint to authenticate a user',
-  description:
-    'Endpoint allows a user to authenticate and access protected resources on the application',
+  description: 'Endpoint allows a user to authenticate and access protected resources on the application',
   requestBody: {
     schema: {
       type: 'object',
@@ -26,8 +25,7 @@ export const login: ApiDocumentationOptions = {
   responses: [
     {
       status: HttpStatus.OK,
-      description:
-        'Login operation was successful and the cookies have been returned',
+      description: 'Login operation was successful and the cookies have been returned',
       headers: {
         'Set-Cookie': {
           description: 'JWT access_token cookie',
@@ -60,24 +58,14 @@ export const login: ApiDocumentationOptions = {
 export const refresh: ApiDocumentationOptions = {
   tag: ['Auth'],
   summary: 'Endpoint to refresh tokens',
-  description:
-    'Endpoint allows a user to get new tokens once the access_token has expired',
-  headers: [
-    {
-      name: 'Cookie',
-      description: 'The cookie required to access the route',
-      required: true,
-      schema: {
-        type: 'string',
-        example: 'refresh_token=TOKEN',
-      },
-    },
-  ],
+  description: 'Endpoint allows a user to get new tokens once the access_token has expired',
+  auth: {
+    cookie: true,
+  },
   responses: [
     {
       status: HttpStatus.OK,
-      description:
-        'Refresh operation was successful and the new cookies have been returned',
+      description: 'Refresh operation was successful and the new cookies have been returned',
       headers: {
         'Set-Cookie': {
           description: 'JWT access_token cookie',
@@ -114,8 +102,7 @@ export const logout: ApiDocumentationOptions = {
   responses: [
     {
       status: HttpStatus.OK,
-      description:
-        'Logout operation was successful and the cookies have been cleared',
+      description: 'Logout operation was successful and the cookies have been cleared',
       schema: {
         type: 'object',
         properties: {

--- a/src/modules/users/docs.ts
+++ b/src/modules/users/docs.ts
@@ -98,6 +98,7 @@ export const findOne: ApiDocumentationOptions = {
       required: true,
     },
   ],
+  auth: { cookie: true },
   responses: [
     {
       status: HttpStatus.OK,
@@ -123,6 +124,9 @@ export const findOne: ApiDocumentationOptions = {
           },
         },
       },
+    },
+    {
+      ...errorTemplates[HttpStatus.UNAUTHORIZED],
     },
     {
       ...errorTemplates[HttpStatus.NOT_FOUND],


### PR DESCRIPTION
# Main changes

- [X] Document attachment routes
- [X] Add cookie authorization on API specification
- [X] Updates on `RouteDoc` decorator to allow the specification of cookie and content-type
- [X] Update route docs for endpoints that required authentication

## Out of scope but was here anyway

- [X] Minor changes to BadRequest exception and filter
- [X] Encrypt attachment key on response