### PR TITLE
fix: use transaction on user sign-in and set all transactions on codebase to isolation level REPEATABLE READ

### DIFF
--- a/src/modules/attachment/attachment.service.ts
+++ b/src/modules/attachment/attachment.service.ts
@@ -10,6 +10,7 @@ import { SignedInUserDTO } from '../auth/dto/signed-in-user.dto';
 import { handleDatabaseCall, isDatabaseException } from '../../common/utils';
 import { PrismaService } from '../../common/database/prisma/prisma.service';
 import { CipherService } from '../../common/cipher/cipher.service';
+import { Prisma } from '@prisma/client';
 
 @Injectable()
 export class AttachmentService {
@@ -30,24 +31,29 @@ export class AttachmentService {
       let uploadedFile;
 
       try {
-        uploadedFile = await this.database.$transaction(async (prismaClient) => {
-          const uploadRecord = await handleDatabaseCall(
-            prismaClient.uploadedFile.create({
-              data: {
-                id: randomUUID(),
-                key,
-                owner: user.accountId,
-                name: file.parsedFilename,
-                extension: file.extension,
-                originalName: file.originalName,
-              },
-            }),
-          );
+        uploadedFile = await this.database.$transaction(
+          async (prismaClient) => {
+            const uploadRecord = await handleDatabaseCall(
+              prismaClient.uploadedFile.create({
+                data: {
+                  id: randomUUID(),
+                  key,
+                  owner: user.accountId,
+                  name: file.parsedFilename,
+                  extension: file.extension,
+                  originalName: file.originalName,
+                },
+              }),
+            );
 
-          await this.S3Service.uploadS3Object(this.config.get('AWS_ATTACHMENTS_BUCKET'), key, file);
+            await this.S3Service.uploadS3Object(this.config.get('AWS_ATTACHMENTS_BUCKET'), key, file);
 
-          return uploadRecord;
-        });
+            return uploadRecord;
+          },
+          {
+            isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead,
+          },
+        );
       } catch (error) {
         if (isDatabaseException(error)) throw new DatabaseException(error);
         else throw error;
@@ -102,13 +108,18 @@ export class AttachmentService {
     }
 
     try {
-      await this.database.$transaction<void>(async (prismaClient) => {
-        await prismaClient.uploadedFile.delete({
-          where: { id: attachmentId, owner: user.accountId },
-        });
+      await this.database.$transaction<void>(
+        async (prismaClient) => {
+          await prismaClient.uploadedFile.delete({
+            where: { id: attachmentId, owner: user.accountId },
+          });
 
-        await this.S3Service.deleteS3Object(this.config.get('AWS_ATTACHMENTS_BUCKET'), attachment.key);
-      });
+          await this.S3Service.deleteS3Object(this.config.get('AWS_ATTACHMENTS_BUCKET'), attachment.key);
+        },
+        {
+          isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead,
+        },
+      );
     } catch (error) {
       if (isDatabaseException(error)) throw new DatabaseException(error);
       else throw error;

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -47,63 +47,66 @@ export class UsersService {
     }
 
     const bcryptRounds = Number(this.config.get('BCRYPT_ROUNDS', { infer: true }));
-
     const hashedPassword = await bcrypt.hash(user.password, bcryptRounds);
     const expiresAt = DateTime.now().plus({ minutes: 5 }).toJSDate();
     const signUpVerificationCode = crypto.randomInt(0, 1000000);
     const hashedSignUpVerificationCode = await bcrypt.hash(String(signUpVerificationCode), bcryptRounds);
-
     let userId = existingVerificationCodes?.length ? existingVerificationCodes[0].userId : undefined;
 
-    if (!userId) {
-      const account = await handleDatabaseCall(this.database.account.create({}));
+    await this.database.$transaction(
+      async (PrismaClient) => {
+        if (!userId) {
+          const account = await handleDatabaseCall(PrismaClient.account.create({}));
 
-      const newUser = await handleDatabaseCall(
-        this.database.user.create({
-          data: {
-            name: user.name,
-            email: user.email,
-            accountId: account!.id,
-            password: hashedPassword,
-          },
-        }),
-        function (error: PrismaException) {
-          if (error instanceof Prisma.PrismaClientKnownRequestError) {
-            if (error.code === errorCodes.UNIQUE_CONSTRAINT_FAILED) {
-              throw new ConflictException('There is already an user registered with the provided email address');
-            }
+          const newUser = await handleDatabaseCall(
+            PrismaClient.user.create({
+              data: {
+                name: user.name,
+                email: user.email,
+                accountId: account!.id,
+                password: hashedPassword,
+              },
+            }),
+            function (error: PrismaException) {
+              if (error instanceof Prisma.PrismaClientKnownRequestError) {
+                if (error.code === errorCodes.UNIQUE_CONSTRAINT_FAILED) {
+                  throw new ConflictException('There is already an user registered with the provided email address');
+                }
+              }
+
+              throw new DatabaseException(error);
+            },
+          );
+
+          if (newUser) {
+            userId = newUser.id;
           }
+        } else {
+          await handleDatabaseCall(
+            PrismaClient.signUpVerificationCode.create({
+              data: {
+                userId,
+                code: hashedSignUpVerificationCode,
+                email: user.email,
+                expiresAt,
+              },
+            }),
+          );
+        }
 
-          throw new DatabaseException(error);
-        },
-      );
-
-      if (newUser) {
-        userId = newUser.id;
-      }
-    }
-
-    if (userId) {
-      await handleDatabaseCall(
-        this.database.signUpVerificationCode.create({
-          data: {
-            userId,
-            code: hashedSignUpVerificationCode,
-            email: user.email,
-            expiresAt,
-          },
-        }),
-      );
-    }
-
-    try {
-      await this.emailService.sendMail(user.email, 'SIGN_UP_CODE', {
-        name: user.name,
-        verificationCode: signUpVerificationCode,
-      });
-    } catch (error) {
-      throw new BaseException(error.message);
-    }
+        try {
+          await this.emailService.sendMail(user.email, 'SIGN_UP_CODE', {
+            name: user.name,
+            verificationCode: signUpVerificationCode,
+          });
+        } catch (error) {
+          throw new BaseException(error.message);
+        }
+      },
+      {
+        isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead,
+      },
+    );
   }
 
   async validateSignUp(signUpInfo: UserDTOs['validateSignUp']): Promise<void> {


### PR DESCRIPTION
# Main changes

- [X] Use transaction on user's sign-in endpoint
- [X] Place all transactions on isolation level of REPEATABLE READ

Upon user sign-in, since there was no transaction a new account could have been created even on 409 errors, polluting the database.

Additionally, all transactions have been modified to use REPEATABLE READ isolation level instead of PostgreSQL's default READ COMMITED. This ensures greater safety against non-repeatable reads and phantom reads and more. This isolation level was chosen over SERIALIZABLE in order to avoid being too strict and having to deal with automatic rollbacks and performance hits.