### PR TITLE
fix: adjust codebase imports to use relative paths from the file instead of paths initiated from src

### DIFF
--- a/src/common/database/prisma/index.ts
+++ b/src/common/database/prisma/index.ts
@@ -1,0 +1,2 @@
+export { default as PrismaService } from './prisma.service';
+export { default as errorCodes } from './error-codes';

--- a/src/common/database/prisma/prisma.service.ts
+++ b/src/common/database/prisma/prisma.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 
 @Injectable()
-export class PrismaService extends PrismaClient implements OnApplicationShutdown {
+export default class PrismaService extends PrismaClient implements OnApplicationShutdown {
   constructor() {
     super({ log: ['warn'] });
   }

--- a/src/common/email/email.module.ts
+++ b/src/common/email/email.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { EmailService } from './email.service';
+import { EmailService } from './index';
 
 @Module({
   providers: [EmailService],

--- a/src/common/email/email.service.ts
+++ b/src/common/email/email.service.ts
@@ -6,7 +6,7 @@ import { EnvSchema } from 'src/config';
 import { AllTypes, TypeToTemplateArgsMap } from './templates/enums';
 
 @Injectable()
-export class EmailService {
+export default class EmailService {
   constructor(private config: ConfigService<EnvSchema, true>) {}
 
   async sendMail<T extends AllTypes>(to: string, type: T, templateArgs: TypeToTemplateArgsMap[T]): Promise<void> {

--- a/src/common/email/index.ts
+++ b/src/common/email/index.ts
@@ -1,0 +1,1 @@
+export { default as EmailService } from './email.service';

--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -4,4 +4,5 @@ export { default as BadRequestException } from './BadRequest.exception';
 export { default as DatabaseException } from './Database.exception';
 export { default as AmazonS3Exception } from './AmazonS3.exception';
 export { default as BaseException } from './Base.exception';
+export { PrismaException } from './Database.exception';
 export { default as errorTypes } from './error-types';

--- a/src/common/validation/index.ts
+++ b/src/common/validation/index.ts
@@ -1,1 +1,2 @@
 export { default as DecryptUUIDPipe } from './decrypt-uuid.pipe';
+export { default as ValidationInterceptor } from './payload-validation.interceptor';

--- a/src/common/validation/payload-validation.interceptor.ts
+++ b/src/common/validation/payload-validation.interceptor.ts
@@ -11,7 +11,7 @@ type SchemaContainer = {
 };
 
 @Injectable()
-export class ValidationInterceptor implements NestInterceptor {
+export default class ValidationInterceptor implements NestInterceptor {
   constructor(public validationObject: SchemaContainer) {}
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {

--- a/src/modules/attachment/attachment.controller.ts
+++ b/src/modules/attachment/attachment.controller.ts
@@ -1,11 +1,11 @@
 import { Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Req, UseGuards, UseInterceptors } from '@nestjs/common';
-import { ValidationInterceptor } from '../../common/validation/payload-validation.interceptor';
+
+import { DecryptUUIDPipe, ValidationInterceptor } from '../../common/validation';
 import { AttachmentInterceptor } from '../../common/attachment';
 import { AttachmentDTOs, default as schemas } from './dto';
 import { AttachmentService } from './attachment.service';
 import { JWTAuthGuard } from '../auth/guards';
 import { AuthenticatedRequest } from '../auth/dto';
-import { DecryptUUIDPipe } from '../../common/validation';
 import * as attachmentDocs from './docs';
 import { RouteDoc } from '../../common/docs';
 

--- a/src/modules/attachment/attachment.module.ts
+++ b/src/modules/attachment/attachment.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
+
 import { AttachmentService } from './attachment.service';
 import { AttachmentController } from './attachment.controller';
 import { S3Service } from '../../common/aws/S3/s3.service';
-import { PrismaService } from '../../common/database/prisma/prisma.service';
+import { PrismaService } from '../../common/database/prisma';
 import { CipherModule } from '../../common/cipher/cipher.module';
 
 @Module({

--- a/src/modules/attachment/attachment.service.ts
+++ b/src/modules/attachment/attachment.service.ts
@@ -1,16 +1,17 @@
-import { S3Service } from '../../common/aws/S3/s3.service';
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { AttachmentDTOs, AttachmentResponseDTOs } from './dto';
-import { randomUUID } from 'crypto';
 import { ConfigService } from '@nestjs/config';
+import { Prisma } from '@prisma/client';
+import { randomUUID } from 'crypto';
+
+import { S3Service } from '../../common/aws/S3/s3.service';
+import { AttachmentDTOs, AttachmentResponseDTOs } from './dto';
 import { EnvSchema } from '../../config';
 import { BaseException, DatabaseException } from '../../common/exceptions';
 import { CreateAttachmentResponseDTO } from './dto/create.response.dto';
 import { SignedInUserDTO } from '../auth/dto/signed-in-user.dto';
 import { handleDatabaseCall, isDatabaseException } from '../../common/utils';
-import { PrismaService } from '../../common/database/prisma/prisma.service';
+import { PrismaService } from '../../common/database/prisma';
 import { CipherService } from '../../common/cipher/cipher.service';
-import { Prisma } from '@prisma/client';
 
 @Injectable()
 export class AttachmentService {

--- a/src/modules/attachment/docs.ts
+++ b/src/modules/attachment/docs.ts
@@ -1,6 +1,7 @@
+import { HttpStatus } from '@nestjs/common';
+
 import { ApiDocumentationOptions } from '../../common/docs/route-doc';
 import { errorTemplates } from '../../common/docs';
-import { HttpStatus } from '@nestjs/common';
 
 export const createAttachment: ApiDocumentationOptions = {
   tag: ['Attachment'],

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -2,12 +2,12 @@ import { Body, Controller, HttpCode, HttpStatus, Post, Req, Res, UseInterceptors
 import { ConfigService } from '@nestjs/config';
 import { Request, Response } from 'express';
 
-import { ValidationInterceptor } from 'src/common/validation/payload-validation.interceptor';
+import { ValidationInterceptor } from '../../common/validation';
 import { AuthDTOs, default as schemas } from './dto';
 import { AuthService } from './auth.service';
-import { default as enums } from 'src/enums';
-import { RouteDoc } from 'src/common/docs';
-import { EnvSchema } from 'src/config';
+import { default as enums } from '../../enums';
+import { RouteDoc } from '../../common/docs';
+import { EnvSchema } from '../../config';
 import * as docs from './docs';
 
 @Controller('auth')

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -1,14 +1,14 @@
 import { PassportModule } from '@nestjs/passport';
+import { ConfigService } from '@nestjs/config';
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 
+import { PrismaModule } from '../../common/database/prisma/prisma.module';
 import { UsersModule } from '../users/users.module';
 import { AuthController } from './auth.controller';
-import { ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './strategies';
-import { EnvSchema } from 'src/config';
-import { PrismaModule } from '../../common/database/prisma/prisma.module';
+import { EnvSchema } from '../../config';
 
 @Module({
   providers: [AuthService, JwtStrategy],

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -6,9 +6,9 @@ import * as bcrypt from 'bcrypt';
 
 import { UsersService } from '../users/users.service';
 import { SignInDTO } from './dto/sign-in.dto';
-import { EnvSchema } from 'src/config';
+import { EnvSchema } from '../../config';
 
-type Tokens = {
+export type Tokens = {
   access_token: string;
   refresh_token: string;
 };

--- a/src/modules/auth/docs.ts
+++ b/src/modules/auth/docs.ts
@@ -1,4 +1,4 @@
-import { ApiDocumentationOptions } from 'src/common/docs/route-doc';
+import { ApiDocumentationOptions } from '../../common/docs/route-doc';
 import { errorTemplates } from '../../common/docs';
 import { HttpStatus } from '@nestjs/common';
 

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -2,11 +2,11 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
-
-import { EnvSchema } from 'src/config';
 import { Request } from 'express';
 import { z as zod } from 'zod';
-import { PrismaService } from '../../../common/database/prisma/prisma.service';
+
+import { PrismaService } from '../../../common/database/prisma/';
+import { EnvSchema } from '../../../config';
 
 const tokenSchema = zod.object({
   sub: zod.string().uuid(),

--- a/src/modules/users/docs.ts
+++ b/src/modules/users/docs.ts
@@ -1,6 +1,6 @@
 import { HttpStatus } from '@nestjs/common';
 import { errorTemplates } from '../../common/docs';
-import { ApiDocumentationOptions } from 'src/common/docs/route-doc';
+import { ApiDocumentationOptions } from '../../common/docs/route-doc';
 
 export const signUp: ApiDocumentationOptions = {
   tag: ['Users'],

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, UseGuards, UseInterceptors } from '@nestjs/common';
 
-import { ValidationInterceptor } from 'src/common/validation/payload-validation.interceptor';
+import { ValidationInterceptor } from '../../common/validation';
 import { default as schemas, UserDTOs } from './dto';
 import { UsersService } from './users.service';
 import { User } from './entities';

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
-import { EmailModule } from 'src/common/email/email.module';
-import { PrismaService } from 'src/common/database/prisma/prisma.service';
+import { EmailModule } from '../../common/email/email.module';
+import { PrismaService } from '../../common/database/prisma';
 import { CipherModule } from '../../common/cipher/cipher.module';
 
 @Module({

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -1,19 +1,22 @@
 import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Prisma } from '@prisma/client';
-import { EnvSchema } from 'src/config';
 import * as crypto from 'crypto';
 import * as bcrypt from 'bcrypt';
 import { DateTime } from 'luxon';
 
-import DatabaseException, { PrismaException } from 'src/common/exceptions/Database.exception';
-import { BaseException, UnprocessableEntityException } from 'src/common/exceptions';
-import { PrismaService } from 'src/common/database/prisma/prisma.service';
+import {
+  BaseException,
+  DatabaseException,
+  errorTypes,
+  PrismaException,
+  UnprocessableEntityException,
+} from 'src/common/exceptions';
+import { errorCodes, PrismaService } from '../../common/database/prisma/';
 import { CipherService } from '../../common/cipher/cipher.service';
-import errorCodes from 'src/common/database/prisma/error-codes';
-import { EmailService } from 'src/common/email/email.service';
-import errorTypes from 'src/common/exceptions/error-types';
-import { handleDatabaseCall } from 'src/common/utils';
+import { handleDatabaseCall } from '../../common/utils';
+import { EmailService } from '../../common/email';
+import { EnvSchema } from '../../config';
 import { User } from './entities';
 import { UserDTOs } from './dto';
 


### PR DESCRIPTION
# Main changes

- [X] add `index.ts` files where needed (mostly in /common)
- [X] adjust imports to use paths relative from the current file on imports

The reason behind this is that, during the creation of unit tests, it was observed that the imports starting with "src/..." could not be resolved by nest when creating the test module.

In order to standardize the imports It was decided to fix the current imports (while the codebase is still relatively small) instead of adding a mapping to "src" on jest config.