### PR TITLE
test: add unit tests for auth module

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: 'src',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '../coverage',
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",
+        "@jest-mock/express": "^3.0.0",
         "@nestjs/cli": "^10.0.0",
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^10.0.0",
@@ -1220,30 +1221,32 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.6.tgz",
-      "integrity": "sha512-aC2DGhBq5eEdyXWqrDInSqQjO0k8xtPRf5YylULqx8MCd6jBtzqfta/3ETMRpuKIc5hyswfO80ObyA1MvkCcUQ==",
+      "version": "7.26.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
+      "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.6.tgz",
-      "integrity": "sha512-qAHSfAdVyFmIvl0VHELib8xar7ONuSHrE2hLnsaWkYNTI68dmi1x8GYDhJjMI/e7XWal9QBlZkwbOnkcw7Z8gQ==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.24.6",
-        "@babel/generator": "^7.24.6",
-        "@babel/helper-compilation-targets": "^7.24.6",
-        "@babel/helper-module-transforms": "^7.24.6",
-        "@babel/helpers": "^7.24.6",
-        "@babel/parser": "^7.24.6",
-        "@babel/template": "^7.24.6",
-        "@babel/traverse": "^7.24.6",
-        "@babel/types": "^7.24.6",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.10",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.10",
+        "@babel/parser": "^7.26.10",
+        "@babel/template": "^7.26.9",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -1268,29 +1271,32 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.6.tgz",
-      "integrity": "sha512-S7m4eNa6YAPJRHmKsLHIDJhNAGNKoWNiWefz1MBbpnt8g9lvMDl1hir4P9bo/57bQEmuwEhnRU/AMWsD0G/Fbg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
+      "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.24.6",
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.6.tgz",
-      "integrity": "sha512-VZQ57UsDGlX/5fFA7GkVPplZhHsVc+vuErWgdOiysI9Ksnw0Pbbd6pnPiR/mmJyKHgyIW0c7KT32gmhiF+cirg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
+      "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.24.6",
-        "@babel/helper-validator-option": "^7.24.6",
-        "browserslist": "^4.22.2",
+        "@babel/compat-data": "^7.26.8",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
@@ -1303,67 +1309,35 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.6.tgz",
-      "integrity": "sha512-Y50Cg3k0LKLMjxdPjIl40SdJgMB85iXn27Vk/qbHZCFx/o5XO3PSnpi675h1KEmmDb6OFArfd5SCQEQ5Q4H88g==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.6.tgz",
-      "integrity": "sha512-xpeLqeeRkbxhnYimfr2PC+iA0Q7ljX/d1eZ9/inYbmfG2jpl8Lu3DyXvpOAnrS5kxkfOWJjioIMQsaMBXFI05w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.24.6",
-        "@babel/types": "^7.24.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.6.tgz",
-      "integrity": "sha512-SF/EMrC3OD7dSta1bLJIlrsVxwtd0UpjRJqLno6125epQMJ/kyFmpTT4pbvPbdQHzCHg+biQ7Syo8lnDtbR+uA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.24.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.6.tgz",
-      "integrity": "sha512-a26dmxFJBF62rRO9mmpgrfTLsAuyHk4e1hKTUkD/fcMfynt8gvEKwQPQDVxWhca8dHoDck+55DFt42zV0QMw5g==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.24.6"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.6.tgz",
-      "integrity": "sha512-Y/YMPm83mV2HJTbX1Qh2sjgjqcacvOlhbzdCCsSlblOKjSYmQqEbO6rUniWQyRo9ncyfjT8hnUjlG06RXDEmcA==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.24.6",
-        "@babel/helper-module-imports": "^7.24.6",
-        "@babel/helper-simple-access": "^7.24.6",
-        "@babel/helper-split-export-declaration": "^7.24.6",
-        "@babel/helper-validator-identifier": "^7.24.6"
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1373,34 +1347,11 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.6.tgz",
-      "integrity": "sha512-MZG/JcWfxybKwsA9N9PmtF2lOSFSEMVCpIRrbxccZFLJPrJciJdG/UhSh5W96GEteJI2ARqm5UAHxISwRDLSNg==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+      "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
       "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.6.tgz",
-      "integrity": "sha512-nZzcMMD4ZhmB35MOOzQuiGO5RzL6tJbsT37Zx8M5L/i9KSrukGXWTjLe1knIbb/RmxoJE9GON9soq0c0VEMM5g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.24.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.6.tgz",
-      "integrity": "sha512-CvLSkwXGWnYlF9+J3iZUvwgAxKiYzK3BWuo+mLzD/MDGOZDj7Gq8+hqaOkMxmJwmlv0iu86uH5fdADd9Hxkymw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.24.6"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1426,10 +1377,11 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.6.tgz",
-      "integrity": "sha512-Jktc8KkF3zIkePb48QO+IapbXlSapOW9S+ogZZkcO6bABgYAxtZcjZ/O005111YLf+j4M84uEgwYoidDkXbCkQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1449,13 +1401,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
-      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+      "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.10"
+        "@babel/types": "^7.27.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1642,34 +1594,32 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.26.9.tgz",
-      "integrity": "sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+      "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/parser": "^7.27.0",
+        "@babel/types": "^7.27.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.6.tgz",
-      "integrity": "sha512-OsNjaJwT9Zn8ozxcfoBc+RaHdj3gFmCmYoQLUII1o6ZrUwku0BMg80FoOTPx+Gi6XhcQxAYE4xyjPTo4SxEQqw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
+      "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.6",
-        "@babel/generator": "^7.24.6",
-        "@babel/helper-environment-visitor": "^7.24.6",
-        "@babel/helper-function-name": "^7.24.6",
-        "@babel/helper-hoist-variables": "^7.24.6",
-        "@babel/helper-split-export-declaration": "^7.24.6",
-        "@babel/parser": "^7.24.6",
-        "@babel/types": "^7.24.6",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.27.0",
+        "@babel/parser": "^7.27.0",
+        "@babel/template": "^7.27.0",
+        "@babel/types": "^7.27.0",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1682,14 +1632,15 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.10",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
-      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2123,6 +2074,41 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jest-mock/express": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@jest-mock/express/-/express-3.0.0.tgz",
+      "integrity": "sha512-omOl6bh4EOUbp9bvcPSBZKaG8nAtBlhVSUhLx0brHrNpEDn+fMtQp58NkhdY3OoUfXjb7go/EcSYwk+H1BVLdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "^5.0.0"
+      }
+    },
+    "node_modules/@jest-mock/express/node_modules/@types/express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.1.tgz",
+      "integrity": "sha512-UZUw8vjpWFXuDnjFTh7/5c2TWDlQqeXHi6hcN7F2XSVT5P+WmUnnbFS3KA6Jnc6IsEqI2qCVu2bK0R0J4A8ZQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@jest-mock/express/node_modules/@types/express-serve-static-core": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
+      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@jest/console": {
@@ -5138,9 +5124,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "dev": true,
       "funding": [
         {
@@ -5156,11 +5142,12 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5281,9 +5268,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001626",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001626.tgz",
-      "integrity": "sha512-JRW7kAH8PFJzoPCJhLSHgDgKg5348hsQ68aqb+slnzuB5QFERv846oA/mRChmlLAOdEDeOkRn3ynb1gSFnjt3w==",
+      "version": "1.0.30001707",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
+      "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
       "dev": true,
       "funding": [
         {
@@ -5298,7 +5285,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -6001,10 +5989,11 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.788",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.788.tgz",
-      "integrity": "sha512-ubp5+Ev/VV8KuRoWnfP2QF2Bg+O2ZFdb49DiiNbz2VmgkIqrnyYaqIOqj8A6K/3p1xV0QcU5hBQ1+BmB6ot1OA==",
-      "dev": true
+      "version": "1.5.125",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.125.tgz",
+      "integrity": "sha512-A2+qEsSUc95QvyFDl7PNwkDDNphIKBVfBBtWWkPGRbiWEgzLo0SvLygYF6HgzVduHd+4WGPB/WD64POFgwzY3g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -6080,10 +6069,11 @@
       "dev": true
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -8323,15 +8313,16 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json-buffer": {
@@ -9027,6 +9018,7 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -9364,10 +9356,11 @@
       "dev": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-      "dev": true
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nodemailer": {
       "version": "6.9.13",
@@ -9719,10 +9712,11 @@
       "peer": true
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "3.0.1",
@@ -11399,9 +11393,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-      "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "dev": true,
       "funding": [
         {
@@ -11417,9 +11411,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -11731,7 +11726,8 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "start:debug": "nest start --debug 0.0.0.0:9229 --watch",
     "start:prod": "node dist/main",
     "lint": "eslint ./src",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test": "jest --config jest.config.js",
+    "test:watch": "jest --watch --config jest.config.js",
+    "test:cov": "jest --coverage --config jest.config.js",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand --config jest.config.js",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "husky:init": "npx husky init",
     "prepare": "husky",
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",
+    "@jest-mock/express": "^3.0.0",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
@@ -86,22 +87,5 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.1.3",
     "typescript-eslint": "^8.4.0"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/src/common/database/prisma/prisma.module.ts
+++ b/src/common/database/prisma/prisma.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { PrismaService } from './prisma.service';
+import { PrismaService } from './index';
 
 @Module({
   providers: [PrismaService],

--- a/src/common/testing/mocks/auth-service.ts
+++ b/src/common/testing/mocks/auth-service.ts
@@ -1,0 +1,16 @@
+import { AuthService } from '../../../modules/auth/auth.service';
+
+type signIn = AuthService['signIn'];
+type refreshToken = AuthService['refreshToken'];
+
+export type MockAuthService = {
+  signIn: jest.Mock<ReturnType<signIn>, Parameters<signIn>>;
+  refreshToken: jest.Mock<ReturnType<refreshToken>, Parameters<refreshToken>>;
+};
+
+export default () => {
+  return {
+    signIn: jest.fn(),
+    refreshToken: jest.fn(),
+  };
+};

--- a/src/common/testing/mocks/config-service.ts
+++ b/src/common/testing/mocks/config-service.ts
@@ -1,0 +1,7 @@
+import { jest } from '@jest/globals';
+
+export default () => {
+  return {
+    get: jest.fn<(parameter: string) => string | string[]>(),
+  };
+};

--- a/src/common/testing/mocks/index.ts
+++ b/src/common/testing/mocks/index.ts
@@ -1,0 +1,5 @@
+export { default as createInterceptor } from './interceptor';
+export { default as createConfigService } from './config-service';
+export { MockUsersService, default as createUsersService } from './users-service';
+export { MockJwtService, default as createJwtService } from './jwt-service';
+export { MockAuthService, default as createAuthService } from './auth-service';

--- a/src/common/testing/mocks/interceptor.ts
+++ b/src/common/testing/mocks/interceptor.ts
@@ -1,0 +1,6 @@
+import { jest } from '@jest/globals';
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+
+export default () => {
+  return jest.fn((_ctx: ExecutionContext, next: CallHandler) => next.handle());
+};

--- a/src/common/testing/mocks/jwt-service.ts
+++ b/src/common/testing/mocks/jwt-service.ts
@@ -1,0 +1,16 @@
+import { JwtService } from '@nestjs/jwt';
+
+type JwtServiceSign = JwtService['sign'];
+type JwtServiceVerifyAsync = JwtService['verifyAsync'];
+
+export type MockJwtService = {
+  sign: jest.Mock<ReturnType<JwtServiceSign>, Parameters<JwtServiceSign>>;
+  verifyAsync: jest.Mock<ReturnType<JwtServiceVerifyAsync>, Parameters<JwtServiceVerifyAsync>>;
+};
+
+export default () => {
+  return {
+    sign: jest.fn(),
+    verifyAsync: jest.fn(),
+  };
+};

--- a/src/common/testing/mocks/users-service.ts
+++ b/src/common/testing/mocks/users-service.ts
@@ -1,0 +1,22 @@
+import { UsersService } from '../../../modules/users/users.service';
+
+type findOneByEmail = UsersService['findOneByEmail'];
+type findOneById = UsersService['findOneById'];
+type validateSignUp = UsersService['validateSignUp'];
+type create = UsersService['create'];
+
+export type MockUsersService = {
+  findOneByEmail: jest.Mock<ReturnType<findOneByEmail>, Parameters<findOneByEmail>>;
+  findOneById: jest.Mock<ReturnType<findOneById>, Parameters<findOneById>>;
+  validateSignUp: jest.Mock<ReturnType<validateSignUp>, Parameters<validateSignUp>>;
+  create: jest.Mock<ReturnType<create>, Parameters<create>>;
+};
+
+export default () => {
+  return {
+    findOneByEmail: jest.fn(),
+    findOneById: jest.fn(),
+    validateSignUp: jest.fn(),
+    create: jest.fn(),
+  };
+};

--- a/src/init/init.module.ts
+++ b/src/init/init.module.ts
@@ -1,7 +1,8 @@
 import { Module } from '@nestjs/common';
-import { EventsModule } from 'src/common/events/events.module';
+
+import { EventsModule } from '../common/events/events.module';
 import { InitService } from './init.service';
-import { PrismaModule } from 'src/common/database/prisma/prisma.module';
+import { PrismaModule } from '../common/database/prisma/prisma.module';
 
 @Module({
   imports: [EventsModule, PrismaModule],

--- a/src/init/init.service.ts
+++ b/src/init/init.service.ts
@@ -1,4 +1,4 @@
-import { PrismaService } from 'src/common/database/prisma/prisma.service';
+import { PrismaService } from 'src/common/database/prisma';
 import { EventService } from '../common/events/events.service';
 import { handleDatabaseCall } from 'src/common/utils';
 import { Injectable, Logger } from '@nestjs/common';

--- a/src/modules/auth/auth.controller.spec.ts
+++ b/src/modules/auth/auth.controller.spec.ts
@@ -1,18 +1,197 @@
+import { getMockReq, getMockRes } from '@jest-mock/express';
 import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { Request, Response } from 'express';
+
+import * as mocks from '../../common/testing/mocks';
 import { AuthController } from './auth.controller';
+import { AuthService, Tokens } from './auth.service';
+import { AuthDTOs } from './dto';
 
 describe('AuthController', () => {
   let controller: AuthController;
+  let authService: mocks.MockAuthService;
+  const configService = mocks.createConfigService();
+  let tokenSets: Tokens[];
+  let mockedResponse: ReturnType<typeof getMockRes>;
 
   beforeEach(async () => {
+    /* Has to be set before the creation of the testing module, otherwise resolves to undefined in the constructor */
+    configService.get.mockReturnValue('production');
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: mocks.createAuthService(),
+        },
+        {
+          provide: ConfigService,
+          useValue: configService,
+        },
+      ],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);
+    authService = module.get<mocks.MockAuthService>(AuthService);
+
+    tokenSets = [
+      { access_token: '{{TOKEN-1}}', refresh_token: '{{TOKEN-2}}' },
+      { access_token: '{{TOKEN-3}}', refresh_token: '{{TOKEN-4}}' },
+    ];
+
+    mockedResponse = getMockRes();
   });
 
-  it('should be defined', () => {
-    expect(controller).toBeDefined();
+  afterEach(() => {
+    mockedResponse.clearMockRes();
+  });
+
+  describe('signIn', () => {
+    let mockSignInReturn: Tokens;
+    let credentials: AuthDTOs['signIn'];
+    let requestResponse: Response;
+
+    beforeEach(() => {
+      mockSignInReturn = tokenSets[0];
+      credentials = { username: 'user', password: 'password' };
+
+      // @ts-expect-error Mocked response does not include deprecated method "sendfile"
+      requestResponse = mockedResponse.res;
+    });
+
+    describe('Response Validation', () => {
+      it('should return a success message', async () => {
+        authService.signIn.mockResolvedValueOnce(mockSignInReturn);
+
+        const response = await controller.signIn(credentials, requestResponse);
+
+        expect(response).toStrictEqual({ message: 'Success' });
+      });
+    });
+
+    describe('Cookies Validation', () => {
+      it('should set the access_token cookie correctly', async () => {
+        authService.signIn.mockResolvedValueOnce(mockSignInReturn);
+
+        await controller.signIn(credentials, requestResponse);
+
+        expect(requestResponse.cookie).toHaveBeenNthCalledWith(1, 'access_token', mockSignInReturn.access_token, {
+          httpOnly: true,
+          secure: true,
+          sameSite: 'strict',
+        });
+      });
+
+      it('should set the refresh_token cookie correctly', async () => {
+        authService.signIn.mockResolvedValueOnce(mockSignInReturn);
+
+        await controller.signIn(credentials, requestResponse);
+
+        expect(requestResponse.cookie).toHaveBeenNthCalledWith(2, 'refresh_token', mockSignInReturn.refresh_token, {
+          httpOnly: true,
+          secure: true,
+          sameSite: 'strict',
+          path: '/auth/refresh',
+        });
+      });
+    });
+  });
+
+  describe('refreshAccessToken', () => {
+    let request: Request;
+    let requestResponse: Response;
+    let mockRefreshTokenReturn: Tokens;
+
+    beforeEach(() => {
+      mockRefreshTokenReturn = tokenSets[1];
+
+      // @ts-expect-error Mocked response does not include deprecated method "sendfile"
+      requestResponse = mockedResponse.res;
+
+      // @ts-expect-error Mocked request does not include deprecated object "param"
+      request = getMockReq({
+        cookies: {
+          ['access_token']: tokenSets[0].access_token,
+          ['refresh_token']: tokenSets[0].refresh_token,
+        },
+      });
+    });
+
+    describe('Response Validation', () => {
+      it('should return a success message', async () => {
+        authService.refreshToken.mockResolvedValueOnce(mockRefreshTokenReturn);
+
+        const response = await controller.refreshAccessToken(request, requestResponse);
+
+        expect(response).toStrictEqual({ message: 'Success' });
+      });
+
+      describe('Cookies Validation', () => {
+        it('should set the access_token cookie correctly', async () => {
+          authService.refreshToken.mockResolvedValueOnce(mockRefreshTokenReturn);
+
+          await controller.refreshAccessToken(request, requestResponse);
+
+          expect(requestResponse.cookie).toHaveBeenNthCalledWith(1, 'access_token', mockRefreshTokenReturn.access_token, {
+            httpOnly: true,
+            secure: true,
+            sameSite: 'strict',
+          });
+        });
+
+        it('should set the refresh_token cookie correctly', async () => {
+          authService.refreshToken.mockResolvedValueOnce(mockRefreshTokenReturn);
+
+          await controller.refreshAccessToken(request, requestResponse);
+
+          expect(requestResponse.cookie).toHaveBeenNthCalledWith(2, 'refresh_token', mockRefreshTokenReturn.refresh_token, {
+            httpOnly: true,
+            secure: true,
+            sameSite: 'strict',
+            path: '/auth/refresh',
+          });
+        });
+      });
+    });
+  });
+
+  describe('logout', () => {
+    let requestResponse: Response;
+
+    beforeEach(() => {
+      // @ts-expect-error Mocked response does not include deprecated method "sendfile"
+      requestResponse = mockedResponse.res;
+    });
+
+    it('should return a success message', async () => {
+      const response = await controller.logout(requestResponse);
+
+      expect(response).toStrictEqual({ message: 'Logged out successfully' });
+    });
+
+    describe('Cookies Validation', () => {
+      it('should clear the access_token cookie correctly', async () => {
+        await controller.logout(requestResponse);
+
+        expect(requestResponse.clearCookie).toHaveBeenNthCalledWith(1, 'access_token', {
+          httpOnly: true,
+          secure: true,
+          sameSite: 'strict',
+        });
+      });
+
+      it('should clear the refresh_token cookie correctly', async () => {
+        await controller.logout(requestResponse);
+
+        expect(requestResponse.clearCookie).toHaveBeenNthCalledWith(2, 'refresh_token', {
+          httpOnly: true,
+          secure: true,
+          sameSite: 'strict',
+          path: '/auth/refresh',
+        });
+      });
+    });
   });
 });

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -12,12 +12,14 @@ import * as docs from './docs';
 
 @Controller('auth')
 export class AuthController {
-  private readonly setSecure: boolean = this.config.get('NODE_ENV') === enums.ENVIRONMENTS.PRODUCTION;
+  private readonly setSecure: boolean;
 
   constructor(
     private authService: AuthService,
     private config: ConfigService<EnvSchema, true>,
-  ) {}
+  ) {
+    this.setSecure = this.config.get('NODE_ENV') === enums.ENVIRONMENTS.PRODUCTION;
+  }
 
   @Post('/login')
   @RouteDoc(docs.login)
@@ -81,6 +83,6 @@ export class AuthController {
       path: '/auth/refresh',
     });
 
-    response.json({ message: 'Logged out successfully' });
+    return { message: 'Logged out successfully' };
   }
 }

--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -1,18 +1,252 @@
+jest.mock('bcrypt');
+
+import { getMockReq } from '@jest-mock/express';
 import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import * as bcrypt from 'bcrypt';
+
+import { UsersService } from '../users/users.service';
+import * as mocks from '../../common/testing/mocks';
+import { ConfigService } from '@nestjs/config';
+import { SignInDTO } from './dto/sign-in.dto';
 import { AuthService } from './auth.service';
+import { User } from '../users/entities';
 
 describe('AuthService', () => {
-  let service: AuthService;
+  let authService: AuthService;
+  let jwtService: mocks.MockJwtService;
+  let usersService: mocks.MockUsersService;
+  const mockedBcrypt = bcrypt as jest.Mocked<typeof bcrypt>;
+  const configService = mocks.createConfigService();
+
+  // Config service variable's returns
+  const accessTokenExpirationTime = '1m';
+  const refreshTokenExpirationTime = '2m';
+  const apiDomain = 'localhost:4000';
+  const allowedOrigins = ['http://localhost:3000'];
+
+  let accessToken: string;
+  let refreshToken: string;
 
   beforeEach(async () => {
+    configService.get.mockReturnValueOnce(accessTokenExpirationTime);
+    configService.get.mockReturnValueOnce(refreshTokenExpirationTime);
+    configService.get.mockReturnValueOnce(apiDomain);
+    configService.get.mockReturnValueOnce(allowedOrigins);
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      providers: [
+        AuthService,
+        {
+          provide: JwtService,
+          useValue: mocks.createJwtService(),
+        },
+        {
+          provide: ConfigService,
+          useValue: configService,
+        },
+        {
+          provide: UsersService,
+          useValue: mocks.createUsersService(),
+        },
+      ],
     }).compile();
 
-    service = module.get<AuthService>(AuthService);
+    // Services
+    authService = module.get<AuthService>(AuthService);
+    jwtService = module.get<mocks.MockJwtService>(JwtService);
+    usersService = module.get<mocks.MockUsersService>(UsersService);
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('signIn', () => {
+    let credentials: SignInDTO;
+    let mockFindOneByEmailReturn: Pick<User, 'id' | 'password'> | null;
+
+    beforeAll(() => {
+      credentials = {
+        username: 'myemail@gmail.com',
+        password: 'superSecretPassword',
+      };
+
+      mockFindOneByEmailReturn = {
+        id: '2cd26018-5a24-4bbc-9824-9374007645cf',
+        password: 'superSecretPassword',
+      };
+    });
+
+    it('should throw an UnauthorizedException if no user is found with the given email address', async () => {
+      usersService.findOneByEmail.mockResolvedValueOnce(null);
+
+      let receivedError;
+      try {
+        await authService.signIn(credentials);
+      } catch (error) {
+        receivedError = error;
+      }
+
+      expect(receivedError.message).toBe('Invalid Credentials');
+      expect(receivedError.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('should throw an UnauthorizedException if the passwords do not match', async () => {
+      usersService.findOneByEmail.mockResolvedValueOnce(mockFindOneByEmailReturn);
+      mockedBcrypt.compare.mockImplementationOnce(() => false);
+
+      let receivedError;
+      try {
+        await authService.signIn(credentials);
+      } catch (error) {
+        receivedError = error;
+      }
+
+      expect(receivedError.message).toBe('Invalid Credentials');
+      expect(receivedError.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    describe('Token validation', () => {
+      beforeEach(() => {
+        accessToken = '{{accessToken}}';
+        refreshToken = '{{refreshToken}}';
+      });
+
+      it('should return the tokens', async () => {
+        usersService.findOneByEmail.mockResolvedValueOnce(mockFindOneByEmailReturn);
+        mockedBcrypt.compare.mockImplementationOnce(() => true);
+        jwtService.sign.mockReturnValueOnce(accessToken);
+        jwtService.sign.mockReturnValueOnce(refreshToken);
+
+        const response = await authService.signIn(credentials);
+
+        expect(response.access_token).toStrictEqual(accessToken);
+        expect(response.refresh_token).toStrictEqual(refreshToken);
+      });
+
+      it('should sign the access_token with the correct parameters', async () => {
+        usersService.findOneByEmail.mockResolvedValueOnce(mockFindOneByEmailReturn);
+        mockedBcrypt.compare.mockImplementationOnce(() => true);
+        jwtService.sign.mockReturnValueOnce(accessToken);
+        jwtService.sign.mockReturnValueOnce(refreshToken);
+
+        await authService.signIn(credentials);
+
+        expect(jwtService.sign).toHaveBeenNthCalledWith(
+          1,
+          { sub: mockFindOneByEmailReturn?.id },
+          {
+            expiresIn: accessTokenExpirationTime,
+            issuer: apiDomain,
+            audience: allowedOrigins,
+          },
+        );
+      });
+
+      it('should sign the refresh_token with the correct parameters', async () => {
+        usersService.findOneByEmail.mockResolvedValueOnce(mockFindOneByEmailReturn);
+        mockedBcrypt.compare.mockImplementationOnce(() => true);
+        jwtService.sign.mockReturnValueOnce(accessToken);
+        jwtService.sign.mockReturnValueOnce(refreshToken);
+
+        await authService.signIn(credentials);
+
+        expect(jwtService.sign).toHaveBeenNthCalledWith(
+          2,
+          { sub: mockFindOneByEmailReturn?.id },
+          {
+            expiresIn: refreshTokenExpirationTime,
+            issuer: apiDomain,
+            audience: allowedOrigins,
+          },
+        );
+      });
+    });
+  });
+
+  describe('RefreshToken', () => {
+    let request: ReturnType<typeof getMockReq>;
+
+    beforeEach(() => {
+      request = getMockReq({
+        cookies: {
+          ['refresh_token']: '{{refreshToken}}',
+        },
+      });
+    });
+
+    it('should throw an UnauthorizedException if the request has no refresh token cookie', async () => {
+      let receivedError;
+      try {
+        // @ts-expect-error Mocked request does not include deprecated object "param"
+        await authService.refreshToken(getMockReq());
+      } catch (error) {
+        receivedError = error;
+      }
+
+      expect(receivedError.message).toBe('No refresh token provided');
+      expect(receivedError.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    describe('Token validation', () => {
+      let jwtVerifyAsyncReturn: { sub: string };
+
+      beforeEach(() => {
+        accessToken = '{{newAccessToken}}';
+        refreshToken = '{{newRefreshToken}}';
+
+        jwtVerifyAsyncReturn = {
+          sub: '{{userId}}',
+        };
+      });
+
+      it('should return the tokens', async () => {
+        jwtService.verifyAsync.mockResolvedValueOnce(jwtVerifyAsyncReturn);
+        jwtService.sign.mockReturnValueOnce(accessToken);
+        jwtService.sign.mockReturnValueOnce(refreshToken);
+
+        // @ts-expect-error Mocked request does not include deprecated object "param"
+        const response = await authService.refreshToken(request);
+
+        expect(response.access_token).toStrictEqual(accessToken);
+        expect(response.refresh_token).toStrictEqual(refreshToken);
+      });
+
+      it('should sign the access_token with the correct parameters', async () => {
+        jwtService.verifyAsync.mockResolvedValueOnce(jwtVerifyAsyncReturn);
+        jwtService.sign.mockReturnValueOnce(accessToken);
+        jwtService.sign.mockReturnValueOnce(refreshToken);
+
+        // @ts-expect-error Mocked request does not include deprecated object "param"
+        await authService.refreshToken(request);
+
+        expect(jwtService.sign).toHaveBeenNthCalledWith(
+          1,
+          { sub: jwtVerifyAsyncReturn.sub },
+          {
+            expiresIn: accessTokenExpirationTime,
+            issuer: apiDomain,
+            audience: allowedOrigins,
+          },
+        );
+      });
+
+      it('should sign the refresh_token with the correct parameters', async () => {
+        jwtService.verifyAsync.mockResolvedValueOnce(jwtVerifyAsyncReturn);
+        jwtService.sign.mockReturnValueOnce(accessToken);
+        jwtService.sign.mockReturnValueOnce(refreshToken);
+
+        // @ts-expect-error Mocked request does not include deprecated object "param"
+        await authService.refreshToken(request);
+
+        expect(jwtService.sign).toHaveBeenNthCalledWith(
+          2,
+          { sub: jwtVerifyAsyncReturn.sub },
+          {
+            expiresIn: refreshTokenExpirationTime,
+            issuer: apiDomain,
+            audience: allowedOrigins,
+          },
+        );
+      });
+    });
   });
 });

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -15,11 +15,21 @@ export type Tokens = {
 
 @Injectable()
 export class AuthService {
+  private readonly accessTokenExpirationTime: string;
+  private readonly refreshTokenExpirationTime: string;
+  private readonly apiDomain: string;
+  private readonly allowedOrigins: string[];
+
   constructor(
     private jwt: JwtService,
     private usersService: UsersService,
     private config: ConfigService<EnvSchema, true>,
-  ) {}
+  ) {
+    this.accessTokenExpirationTime = this.config.get('ACCESS_TOKEN_EXPIRATION_TIME');
+    this.refreshTokenExpirationTime = this.config.get('REFRESH_TOKEN_EXPIRATION_TIME');
+    this.apiDomain = this.config.get('API_DOMAIN');
+    this.allowedOrigins = this.config.get('ALLOWED_ORIGINS');
+  }
 
   async signIn({ username, password }: SignInDTO): Promise<Tokens> {
     const user = await this.usersService.findOneByEmail({ email: username });
@@ -36,18 +46,18 @@ export class AuthService {
     const access_token = this.jwt.sign(
       { sub: user.id },
       {
-        expiresIn: this.config.get('ACCESS_TOKEN_EXPIRATION_TIME'),
-        issuer: this.config.get('API_DOMAIN'),
-        audience: this.config.get('ALLOWED_ORIGINS'),
+        expiresIn: this.accessTokenExpirationTime,
+        issuer: this.apiDomain,
+        audience: this.allowedOrigins,
       },
     );
 
     const refresh_token = this.jwt.sign(
       { sub: user.id },
       {
-        expiresIn: this.config.get('REFRESH_TOKEN_EXPIRATION_TIME'),
-        issuer: this.config.get('API_DOMAIN'),
-        audience: this.config.get('ALLOWED_ORIGINS'),
+        expiresIn: this.refreshTokenExpirationTime,
+        issuer: this.apiDomain,
+        audience: this.allowedOrigins,
       },
     );
 
@@ -67,18 +77,18 @@ export class AuthService {
     const access_token = this.jwt.sign(
       { sub },
       {
-        expiresIn: this.config.get('ACCESS_TOKEN_EXPIRATION_TIME'),
-        issuer: this.config.get('API_DOMAIN'),
-        audience: this.config.get('ALLOWED_ORIGINS'),
+        expiresIn: this.accessTokenExpirationTime,
+        issuer: this.apiDomain,
+        audience: this.allowedOrigins,
       },
     );
 
     const refresh_token = this.jwt.sign(
       { sub },
       {
-        expiresIn: this.config.get('REFRESH_TOKEN_EXPIRATION_TIME'),
-        issuer: this.config.get('API_DOMAIN'),
-        audience: this.config.get('ALLOWED_ORIGINS'),
+        expiresIn: this.refreshTokenExpirationTime,
+        issuer: this.apiDomain,
+        audience: this.allowedOrigins,
       },
     );
 

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -11,7 +11,7 @@ import {
   errorTypes,
   PrismaException,
   UnprocessableEntityException,
-} from 'src/common/exceptions';
+} from '../../common/exceptions';
 import { errorCodes, PrismaService } from '../../common/database/prisma/';
 import { CipherService } from '../../common/cipher/cipher.service';
 import { handleDatabaseCall } from '../../common/utils';
@@ -169,10 +169,14 @@ export class UsersService {
   }
 
   // Used by Auth
-  async findOneByEmail(payload: UserDTOs['findOneByEmail']): Promise<User | null> {
+  async findOneByEmail(payload: UserDTOs['findOneByEmail']): Promise<Pick<User, 'id' | 'password'> | null> {
     const user = await handleDatabaseCall(
       this.database.user.findUnique({
         where: { email: payload.email },
+        select: {
+          id: true,
+          password: true,
+        },
       }),
     );
 


### PR DESCRIPTION
# Main changes

- [X] Add `/testing/mocks` in `common`
- [X] Add unit tests for Auth module
- [X] Move jest config from package.json to dedicated file `jest.config.js`

## Out of scope but fixed

- [X] Some left-over imports with `src`
- [X] Refactor of auth service to avoid duplicate call to get env variables
- [X] Select only id and password from users service's findOneByEmail during auth (increases performance)
- 