### PR TITLE
chore: add collect and ignore coverage patterns for unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,8 +8,9 @@ module.exports = {
   transform: {
     '^.+\\.(t|j)s$': 'ts-jest',
   },
-  collectCoverageFrom: ['**/*.(t|j)s'],
   coverageDirectory: '../coverage',
   clearMocks: true,
   setupFilesAfterEnv: ['<rootDir>/common/testing/mocks/prisma/prisma-service.ts'],
+  collectCoverageFrom: ['**/*.service.ts', '**/*.controller.ts', '**/*.interceptor.ts'],
+  coveragePathIgnorePatterns: ['/src/init/', 'src/common/httpClient/', 'src/common/database'],
 };


### PR DESCRIPTION
# Main changes

- [X] sets `.controller`, `.service` and `.interceptor` files as qualified for coverage reports
- [X] sets some directories to ignore from coverage, such as: init, database and httpClient