### PR TITLE
feat: enforce content-type validation for write operations

### DIFF
--- a/src/common/attachment/attachment.interceptor.spec.ts
+++ b/src/common/attachment/attachment.interceptor.spec.ts
@@ -1,8 +1,8 @@
 import * as http from 'http';
 
 import { default as AttachmentInterceptor } from './attachment.interceptor';
-import { default as enums } from '../../enums';
 import { AttachmentUploadException, errorTypes } from '../exceptions';
+import { FILE_EXTENSION, FILE_MIMETYPE } from '../../enums';
 import * as mocks from '../testing/mocks';
 
 const createMockedRequest = (fileName: string, mimetype: string, contentType: string) => {
@@ -38,7 +38,7 @@ describe('Attachment Interceptor', () => {
     it('should fill req.body with the processed files', async () => {
       const filename = '  d,u,m,m,y.pdf';
       const interceptor = new AttachmentInterceptor({ maxFileSizeInBytes: 2048 });
-      const { request, response } = createMockedRequest(filename, enums.FILE_MIMETYPE.PDF, 'multipart/form-data');
+      const { request, response } = createMockedRequest(filename, FILE_MIMETYPE.PDF, FILE_MIMETYPE.MULTIPART_FORM_DATA);
       const executionContext = mocks.createExecutionContext(request, response);
       const callHandler = mocks.createCallHandler({});
 
@@ -49,8 +49,8 @@ describe('Attachment Interceptor', () => {
         files: [
           {
             buffer: expect.any(Buffer) as Buffer,
-            mimeType: enums.FILE_MIMETYPE.PDF,
-            extension: enums.FILE_EXTENSION.PDF,
+            mimeType: FILE_MIMETYPE.PDF,
+            extension: FILE_EXTENSION.PDF,
             size: expect.any(Number) as number,
             originalName: filename,
             parsedFilename: 'd.u.m.m.y.pdf',
@@ -63,7 +63,7 @@ describe('Attachment Interceptor', () => {
   describe('Error Validation', () => {
     it('should throw an AttachmentUploadException if the content-type is not "multipart/form-data"', async () => {
       const interceptor = new AttachmentInterceptor({ maxFileSizeInBytes: 2048 });
-      const { request, response } = createMockedRequest('data.json', enums.FILE_MIMETYPE.JSON, enums.FILE_MIMETYPE.JSON);
+      const { request, response } = createMockedRequest('data.json', FILE_MIMETYPE.JSON, FILE_MIMETYPE.JSON);
       const executionContext = mocks.createExecutionContext(request, response);
       const callHandler = mocks.createCallHandler({});
 
@@ -81,7 +81,7 @@ describe('Attachment Interceptor', () => {
     it('should throw an AttachmentUploadException if the file size exceeds the pre-defined allowed limit', async () => {
       const fileName = 'dummy.pdf';
       const interceptor = new AttachmentInterceptor({ maxFileSizeInBytes: 10 });
-      const { request, response } = createMockedRequest(fileName, enums.FILE_MIMETYPE.PDF, 'multipart/form-data');
+      const { request, response } = createMockedRequest(fileName, FILE_MIMETYPE.PDF, FILE_MIMETYPE.MULTIPART_FORM_DATA);
       const executionContext = mocks.createExecutionContext(request, response);
       const callHandler = mocks.createCallHandler({});
 

--- a/src/common/aws/S3/s3.service.spec.ts
+++ b/src/common/aws/S3/s3.service.spec.ts
@@ -23,7 +23,7 @@ import { Upload } from '@aws-sdk/lib-storage';
 import { HttpStatus } from '@nestjs/common';
 
 import type { Attachment } from '../../attachment/attachment.interceptor';
-import { default as enums } from '../../../enums';
+import { FILE_EXTENSION, FILE_MIMETYPE } from '../../../enums';
 import * as mocks from '../../testing/mocks';
 import { S3Service } from './s3.service';
 
@@ -62,8 +62,8 @@ describe('S3 Service', () => {
 
     beforeEach(() => {
       file = {
-        mimeType: enums.FILE_MIMETYPE.PDF,
-        extension: enums.FILE_EXTENSION.PDF,
+        mimeType: FILE_MIMETYPE.PDF,
+        extension: FILE_EXTENSION.PDF,
         originalName: 'dummy.pdf',
         parsedFilename: 'dummy.pdf',
         size: 10000,

--- a/src/common/docs/error-templates.ts
+++ b/src/common/docs/error-templates.ts
@@ -160,4 +160,49 @@ export default Object.seal({
       },
     },
   },
+
+  [HttpStatus.UNSUPPORTED_MEDIA_TYPE]: {
+    status: HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+    description: 'Unsupported Media Type. The supported types will be present in the response header Accept-*.',
+    headers: {
+      'Accept-Post': {
+        description: 'Supported content types for POST requests',
+        schema: {
+          type: 'string',
+          example: 'multipart/form-data, application/json',
+        },
+      },
+      'Accept-Patch': {
+        description: 'Supported content types for PATCH requests',
+        schema: {
+          type: 'string',
+          example: 'application/json',
+        },
+      },
+      Accept: {
+        description: 'Supported content types for requests',
+        schema: {
+          type: 'string',
+          example: 'application/json',
+        },
+      },
+    },
+    schema: {
+      type: 'object',
+      properties: {
+        statusCode: {
+          type: 'number',
+          example: HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+        },
+        timestamp: {
+          type: 'Date',
+          example: '2024-08-25T15:52:11.260Z',
+        },
+        message: {
+          type: 'string',
+          example: `Unsupported Media Type. Expected: {type(s)}`,
+        },
+      },
+    },
+  },
 });

--- a/src/common/exceptions/UnsupportedMediaTypeException.ts
+++ b/src/common/exceptions/UnsupportedMediaTypeException.ts
@@ -1,0 +1,11 @@
+import { HttpStatus } from '@nestjs/common';
+import BaseException from './Base.exception';
+
+export default class UnsupportedMediaTypeException extends BaseException {
+  name: string;
+
+  constructor(readonly message: string = 'Unsupported Media Type') {
+    super(message, HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+    this.name = 'UnsupportedMediaTypeException';
+  }
+}

--- a/src/common/exceptions/filters/GlobalException.filter.ts
+++ b/src/common/exceptions/filters/GlobalException.filter.ts
@@ -48,6 +48,7 @@ export default class GlobalExceptionFilter implements ExceptionFilter {
       errors.ConflictException.name,
       errors.NotFoundException.name,
       errors.UnprocessableEntityException.name,
+      errors.UnsupportedMediaTypeException.name,
     ];
 
     const shouldSkipLogging = errorToAvoidLogging.some((errorClass) => errorClass === exception.name);

--- a/src/common/exceptions/index.ts
+++ b/src/common/exceptions/index.ts
@@ -1,3 +1,4 @@
+export { default as UnsupportedMediaTypeException } from './UnsupportedMediaTypeException';
 export { default as UnprocessableEntityException } from './UnprocessableEntity.exception';
 export { default as AttachmentUploadException } from './AttachmentUploadException';
 export { default as BadRequestException } from './BadRequest.exception';

--- a/src/common/validation/decorators/content-type.decorator.ts
+++ b/src/common/validation/decorators/content-type.decorator.ts
@@ -1,0 +1,5 @@
+import { CustomDecorator, SetMetadata } from '@nestjs/common';
+import { FILE_MIMETYPE } from '../../../enums';
+
+export const ACCEPT_CONTENT_TYPE_KEY = 'acceptContentType';
+export default (...contentTypes: FILE_MIMETYPE[]): CustomDecorator => SetMetadata(ACCEPT_CONTENT_TYPE_KEY, contentTypes);

--- a/src/common/validation/decorators/index.ts
+++ b/src/common/validation/decorators/index.ts
@@ -1,0 +1,1 @@
+export { default as AcceptContentType } from './content-type.decorator';

--- a/src/common/validation/guards/content-type.guard.ts
+++ b/src/common/validation/guards/content-type.guard.ts
@@ -1,0 +1,58 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import type { Request, Response } from 'express';
+import { Observable } from 'rxjs';
+
+import { ACCEPT_CONTENT_TYPE_KEY } from '../decorators/content-type.decorator';
+import { UnsupportedMediaTypeException } from '../../exceptions';
+import { HTTP_METHODS } from '../../../enums';
+
+@Injectable()
+export default class ContentTypeGuard implements CanActivate {
+  private readonly DEFAULT_CONTENT_TYPE = 'application/json';
+
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+    const request: Request = context.switchToHttp().getRequest();
+    const methodsToSkipCheck = [HTTP_METHODS.GET, HTTP_METHODS.DELETE];
+    const shouldSkipContentTypeCheck = methodsToSkipCheck.includes(request.method.toUpperCase() as HTTP_METHODS);
+
+    if (!shouldSkipContentTypeCheck) {
+      const acceptedContentTypes = this.reflector.get<string[] | undefined>(ACCEPT_CONTENT_TYPE_KEY, context.getHandler()) ?? [
+        this.DEFAULT_CONTENT_TYPE,
+      ];
+
+      const contentType = request.headers['content-type']?.split(';')[0];
+
+      if (!contentType || !acceptedContentTypes.includes(contentType)) {
+        const response: Response = context.switchToHttp().getResponse();
+        this.addAcceptHeaders(response, request.method as HTTP_METHODS, acceptedContentTypes);
+
+        throw new UnsupportedMediaTypeException(`Unsupported Media Type. Expected: ${acceptedContentTypes.join(', ')}`);
+      }
+
+      return true;
+    }
+
+    return true;
+  }
+
+  private addAcceptHeaders(response: Response, method: HTTP_METHODS, acceptedTypes: string[]): void {
+    switch (method) {
+      case HTTP_METHODS.POST:
+        response.header('Accept-Post', acceptedTypes);
+        break;
+      case HTTP_METHODS.PATCH:
+        response.header('Accept-Patch', acceptedTypes);
+        break;
+      case HTTP_METHODS.OPTIONS:
+        response.header('Accept-Post', acceptedTypes);
+        response.header('Accept-Patch', acceptedTypes);
+        response.header('Accept', acceptedTypes);
+        break;
+      default:
+        response.header('Accept', acceptedTypes);
+    }
+  }
+}

--- a/src/common/validation/index.ts
+++ b/src/common/validation/index.ts
@@ -1,2 +1,3 @@
+export { AcceptContentType } from './decorators';
 export { default as DecryptUUIDPipe } from './decrypt-uuid.pipe';
 export { default as ValidationInterceptor } from './payload-validation.interceptor';

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,35 +1,38 @@
-export default {
-  ENVIRONMENTS: {
-    DEVELOPMENT: 'development',
-    STAGING: 'staging',
-    PRODUCTION: 'production',
-  },
+export enum ENVIRONMENTS {
+  DEVELOPMENT = 'development',
+  STAGING = 'staging',
+  PRODUCTION = 'production',
+}
 
-  USER_TYPE: {
-    TECHNICAL: 1,
-    NON_TECHNICAL: 2,
-  },
+export enum FILE_MIMETYPE {
+  ZIP = 'application/zip',
+  RAR = 'application/x-rar-compressed',
+  EXCEL = 'application/vnd.ms-excel',
+  WORD = 'application/msword',
+  XML = 'application/xml',
+  JPEG = 'image/jpeg',
+  PNG = 'image/png',
+  SVG = 'image/svg+xml',
+  PDF = 'application/pdf',
+  JSON = 'application/json',
+  MULTIPART_FORM_DATA = 'multipart/form-data',
+}
 
-  FILE_MIMETYPE: {
-    ZIP: 'application/zip',
-    RAR: 'application/x-rar-compressed',
-    EXCEL: 'application/vnd.ms-excel',
-    WORD: 'application/msword',
-    XML: 'application/xml',
-    JPEG: 'image/jpeg',
-    PNG: 'image/png',
-    SVG: 'image/svg+xml',
-    PDF: 'application/pdf',
-    JSON: 'application/json',
-  },
+export enum FILE_EXTENSION {
+  XML = 'xml',
+  JPEG = 'jpeg',
+  JPG = 'jpg',
+  PNG = 'png',
+  PDF = 'pdf',
+  SVG = 'svg',
+  JSON = 'json',
+}
 
-  FILE_EXTENSION: {
-    XML: 'xml',
-    JPEG: 'jpeg',
-    JPG: 'jpg',
-    PNG: 'png',
-    PDF: 'pdf',
-    SVG: 'svg',
-    JSON: 'json',
-  },
-};
+export enum HTTP_METHODS {
+  GET = 'GET',
+  POST = 'POST',
+  PUT = 'PUT',
+  PATCH = 'PATCH',
+  DELETE = 'DELETE',
+  OPTIONS = 'OPTIONS',
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,17 +1,20 @@
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { NestFactory, Reflector } from '@nestjs/core';
 import { ConfigService } from '@nestjs/config';
 import * as cookieParser from 'cookie-parser';
-import { NestFactory } from '@nestjs/core';
 import type { CorsOptions } from 'cors';
-import { Logger } from '@nestjs/common';
+import { HttpStatus, Logger } from '@nestjs/common';
 import * as passport from 'passport';
 import helmet from 'helmet';
 
+import { default as ContentTypeGuard } from './common/validation/guards/content-type.guard';
 import * as exceptionFilters from './common/exceptions/filters';
 import { EventService } from './common/events/events.service';
 import { InitService } from './init/init.service';
 import { AppModule } from './app.module';
 import { EnvSchema } from './config';
+
+import { default as errorTemplates } from './common/docs/error-templates';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -52,6 +55,7 @@ async function bootstrap() {
       in: 'cookie',
       name: 'access_token',
     })
+    .addGlobalResponse(errorTemplates[HttpStatus.INTERNAL_SERVER_ERROR])
     .build();
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('docs', app, document);
@@ -67,6 +71,9 @@ async function bootstrap() {
     new exceptionFilters.AttachmentUploadExceptionFilter(),
     new exceptionFilters.UnprocessableEntityExceptionFilter(),
   );
+
+  // Global Guards
+  app.useGlobalGuards(new ContentTypeGuard(new Reflector()));
 
   await initService.init();
 }

--- a/src/modules/attachment/attachment.controller.ts
+++ b/src/modules/attachment/attachment.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Delete, Get, HttpCode, HttpStatus, Param, Post, Req, UseGuards, UseInterceptors } from '@nestjs/common';
 
-import { DecryptUUIDPipe, ValidationInterceptor } from '../../common/validation';
+import { AcceptContentType, DecryptUUIDPipe, ValidationInterceptor } from '../../common/validation';
 import { AttachmentInterceptor } from '../../common/attachment';
 import { AttachmentDTOs, default as schemas } from './dto';
 import { AttachmentService } from './attachment.service';
@@ -8,6 +8,7 @@ import { JWTAuthGuard } from '../auth/guards';
 import { AuthenticatedRequest } from '../auth/dto';
 import * as attachmentDocs from './docs';
 import { RouteDoc } from '../../common/docs';
+import { FILE_MIMETYPE } from '../../enums';
 
 @Controller('attachments')
 export class AttachmentController {
@@ -16,6 +17,7 @@ export class AttachmentController {
   @Post('/')
   @UseGuards(JWTAuthGuard)
   @RouteDoc(attachmentDocs.createAttachment)
+  @AcceptContentType(FILE_MIMETYPE.MULTIPART_FORM_DATA)
   @UseInterceptors(new AttachmentInterceptor({ maxFileSizeInBytes: 2 * 1024 * 1024 }), new ValidationInterceptor(schemas.create))
   @HttpCode(HttpStatus.CREATED)
   create(@Req() req: AuthenticatedRequest) {

--- a/src/modules/attachment/attachment.service.spec.ts
+++ b/src/modules/attachment/attachment.service.spec.ts
@@ -2,16 +2,16 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { Prisma } from '@prisma/client';
 
+import { DatabaseException, NotFoundException } from '../../common/exceptions';
 import { errorCodes, PrismaService } from '../../common/database/prisma';
 import { CipherService } from '../../common/cipher/cipher.service';
 import { SignedInUserDTO } from '../auth/dto/signed-in-user.dto';
 import { AttachmentDTOs, AttachmentResponseDTOs } from './dto';
-import { DatabaseException, NotFoundException } from '../../common/exceptions';
 import { S3Service } from '../../common/aws/S3/s3.service';
 import { AttachmentService } from './attachment.service';
 import * as mocks from '../../common/testing/mocks';
 import * as entities from '../../common/entities';
-import { default as enums } from '../../enums';
+import { FILE_MIMETYPE } from '../../enums';
 
 describe('attachmentsService', () => {
   const configService = mocks.createConfigService();
@@ -80,8 +80,8 @@ describe('attachmentsService', () => {
           originalName: 'dummy.pdf',
           size: 10000,
           buffer: Buffer.from('some file data'),
-          mimeType: enums.FILE_MIMETYPE.PDF,
-          extension: enums.FILE_MIMETYPE.PDF,
+          mimeType: FILE_MIMETYPE.PDF,
+          extension: FILE_MIMETYPE.PDF,
         },
       ];
 

--- a/src/modules/attachment/docs.ts
+++ b/src/modules/attachment/docs.ts
@@ -10,6 +10,17 @@ export const createAttachment: ApiDocumentationOptions = {
   auth: {
     cookie: true,
   },
+  headers: [
+    {
+      name: 'Content-Type',
+      description: 'The content type of the request body',
+      required: true,
+      schema: {
+        type: 'string',
+        example: 'multipart/form-data',
+      },
+    },
+  ],
   requestBody: {
     contentType: 'multipart/form-data',
     schema: {
@@ -49,13 +60,13 @@ export const createAttachment: ApiDocumentationOptions = {
       ...errorTemplates[HttpStatus.UNAUTHORIZED],
     },
     {
+      ...errorTemplates[HttpStatus.UNSUPPORTED_MEDIA_TYPE],
+    },
+    {
       ...errorTemplates[HttpStatus.UNPROCESSABLE_ENTITY],
       description:
         'Possible error types:<br><br>' +
         '`attachments.create.file_size_limit_exceeded` - Happens when one or more attachments have exceeded the file size limit',
-    },
-    {
-      ...errorTemplates[HttpStatus.INTERNAL_SERVER_ERROR],
     },
   ],
 };
@@ -98,9 +109,6 @@ export const downloadAttachment: ApiDocumentationOptions = {
     {
       ...errorTemplates[HttpStatus.NOT_FOUND],
     },
-    {
-      ...errorTemplates[HttpStatus.INTERNAL_SERVER_ERROR],
-    },
   ],
 };
 
@@ -131,9 +139,6 @@ export const deleteAttachment: ApiDocumentationOptions = {
     },
     {
       ...errorTemplates[HttpStatus.NOT_FOUND],
-    },
-    {
-      ...errorTemplates[HttpStatus.INTERNAL_SERVER_ERROR],
     },
   ],
 };

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -5,7 +5,7 @@ import { Request, Response } from 'express';
 import { ValidationInterceptor } from '../../common/validation';
 import { AuthDTOs, default as schemas } from './dto';
 import { AuthService } from './auth.service';
-import { default as enums } from '../../enums';
+import { ENVIRONMENTS } from '../../enums';
 import { RouteDoc } from '../../common/docs';
 import { EnvSchema } from '../../config';
 import * as docs from './docs';
@@ -18,7 +18,7 @@ export class AuthController {
     private authService: AuthService,
     private config: ConfigService<EnvSchema, true>,
   ) {
-    this.setSecure = this.config.get('NODE_ENV') === enums.ENVIRONMENTS.PRODUCTION;
+    this.setSecure = this.config.get('NODE_ENV') === ENVIRONMENTS.PRODUCTION;
   }
 
   @Post('/login')

--- a/src/modules/auth/docs.ts
+++ b/src/modules/auth/docs.ts
@@ -6,6 +6,17 @@ export const login: ApiDocumentationOptions = {
   tag: ['Auth'],
   summary: 'Endpoint to authenticate a user',
   description: 'Endpoint allows a user to authenticate and access protected resources on the application',
+  headers: [
+    {
+      name: 'Content-Type',
+      description: 'The content type of the request body',
+      required: true,
+      schema: {
+        type: 'string',
+        example: 'application/json',
+      },
+    },
+  ],
   requestBody: {
     schema: {
       type: 'object',
@@ -51,7 +62,9 @@ export const login: ApiDocumentationOptions = {
       },
     },
     { ...errorTemplates[HttpStatus.UNAUTHORIZED] },
-    { ...errorTemplates[HttpStatus.INTERNAL_SERVER_ERROR] },
+    {
+      ...errorTemplates[HttpStatus.UNSUPPORTED_MEDIA_TYPE],
+    },
   ],
 };
 
@@ -59,6 +72,17 @@ export const refresh: ApiDocumentationOptions = {
   tag: ['Auth'],
   summary: 'Endpoint to refresh tokens',
   description: 'Endpoint allows a user to get new tokens once the access_token has expired',
+  headers: [
+    {
+      name: 'Content-Type',
+      description: 'The content type of the request body',
+      required: true,
+      schema: {
+        type: 'string',
+        example: 'application/json',
+      },
+    },
+  ],
   auth: {
     cookie: true,
   },
@@ -91,7 +115,9 @@ export const refresh: ApiDocumentationOptions = {
       },
     },
     { ...errorTemplates[HttpStatus.UNAUTHORIZED] },
-    { ...errorTemplates[HttpStatus.INTERNAL_SERVER_ERROR] },
+    {
+      ...errorTemplates[HttpStatus.UNSUPPORTED_MEDIA_TYPE],
+    },
   ],
 };
 
@@ -99,6 +125,17 @@ export const logout: ApiDocumentationOptions = {
   tag: ['Auth'],
   summary: 'Endpoint to clear tokens',
   description: 'Endpoint to clear tokens, effectively logging the user out',
+  headers: [
+    {
+      name: 'Content-Type',
+      description: 'The content type of the request body',
+      required: true,
+      schema: {
+        type: 'string',
+        example: 'application/json',
+      },
+    },
+  ],
   responses: [
     {
       status: HttpStatus.OK,
@@ -113,6 +150,8 @@ export const logout: ApiDocumentationOptions = {
         },
       },
     },
-    { ...errorTemplates[HttpStatus.INTERNAL_SERVER_ERROR] },
+    {
+      ...errorTemplates[HttpStatus.UNSUPPORTED_MEDIA_TYPE],
+    },
   ],
 };

--- a/src/modules/users/docs.ts
+++ b/src/modules/users/docs.ts
@@ -6,6 +6,17 @@ export const signUp: ApiDocumentationOptions = {
   tag: ['Users'],
   summary: 'Signs Up a user',
   description: "Endpoint used to create a new user and send a verification code to the user's email address",
+  headers: [
+    {
+      name: 'Content-Type',
+      description: 'The content type of the request body',
+      required: true,
+      schema: {
+        type: 'string',
+        example: 'application/json',
+      },
+    },
+  ],
   requestBody: {
     schema: {
       type: 'object',
@@ -37,16 +48,16 @@ export const signUp: ApiDocumentationOptions = {
       description: 'Sign up successful',
     },
     {
-      ...errorTemplates[HttpStatus.UNPROCESSABLE_ENTITY],
-      description:
-        'Possible error codes: \n\n`users.create.sign_up_code_still_active` - Happens when the user still has an active verification code, preventing the creation of a new one.',
-    },
-    {
       ...errorTemplates[HttpStatus.CONFLICT],
       description: 'Happens when a user is already registered with the email address provided',
     },
     {
-      ...errorTemplates[HttpStatus.INTERNAL_SERVER_ERROR],
+      ...errorTemplates[HttpStatus.UNSUPPORTED_MEDIA_TYPE],
+    },
+    {
+      ...errorTemplates[HttpStatus.UNPROCESSABLE_ENTITY],
+      description:
+        'Possible error codes: <br><br>`users.create.sign_up_code_still_active` - Happens when the user still has an active verification code, preventing the creation of a new one.',
     },
   ],
 };
@@ -55,6 +66,17 @@ export const validateSignUp: ApiDocumentationOptions = {
   tag: ['Users'],
   summary: "Validates a user's sign-up code",
   description: 'Endpoint used to validate a sign-up code',
+  headers: [
+    {
+      name: 'Content-Type',
+      description: 'The content type of the request body',
+      required: true,
+      schema: {
+        type: 'string',
+        example: 'application/json',
+      },
+    },
+  ],
   requestBody: {
     schema: {
       type: 'object',
@@ -77,12 +99,12 @@ export const validateSignUp: ApiDocumentationOptions = {
       description: 'Sign up validation successful',
     },
     {
-      ...errorTemplates[HttpStatus.UNPROCESSABLE_ENTITY],
-      description:
-        'Possible error codes: \n\n`users.validate_sign_up.code.invalid_or_expired` - Happens when the provided sign-up code is either invalid or has already expired',
+      ...errorTemplates[HttpStatus.UNSUPPORTED_MEDIA_TYPE],
     },
     {
-      ...errorTemplates[HttpStatus.INTERNAL_SERVER_ERROR],
+      ...errorTemplates[HttpStatus.UNPROCESSABLE_ENTITY],
+      description:
+        'Possible error codes: <br><br>`users.validate_sign_up.code.invalid_or_expired` - Happens when the provided sign-up code is either invalid or has already expired',
     },
   ],
 };
@@ -130,9 +152,6 @@ export const findOne: ApiDocumentationOptions = {
     },
     {
       ...errorTemplates[HttpStatus.NOT_FOUND],
-    },
-    {
-      ...errorTemplates[HttpStatus.INTERNAL_SERVER_ERROR],
     },
   ],
 };


### PR DESCRIPTION

# Main changes

- Creates custom decorator and guard to handle request's content-type validation on write operations (POST, PUT, PATCH)
- Adds error template for 415 (Unsupported Media Type)
- Implement guard globally (expecting `application/json` by default)
- Implement decorator on upload attachment route (overrides default)
- Small changes on enum
- Removes 500 error template from individual routes and place it as a global response