### PR TITLE
refactor: Refactor Prisma integration into a global module

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { envSchema } from './config';
 import { AuthModule } from './modules/auth/auth.module';
 import { AuthController } from './modules/auth/auth.controller';
 import { AttachmentModule } from './modules/attachment/attachment.module';
+import { PrismaModule } from './common/database/prisma/prisma.module';
 
 const logger = new Logger('AppModule');
 
@@ -30,6 +31,7 @@ const logger = new Logger('AppModule');
         return env;
       },
     }),
+    PrismaModule,
     UsersModule,
     EventsModule,
     InitModule,

--- a/src/common/database/prisma/prisma.module.ts
+++ b/src/common/database/prisma/prisma.module.ts
@@ -1,6 +1,7 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import { PrismaService } from './index';
 
+@Global()
 @Module({
   providers: [PrismaService],
   exports: [PrismaService],

--- a/src/init/init.module.ts
+++ b/src/init/init.module.ts
@@ -2,10 +2,9 @@ import { Module } from '@nestjs/common';
 
 import { EventsModule } from '../common/events/events.module';
 import { InitService } from './init.service';
-import { PrismaModule } from '../common/database/prisma/prisma.module';
 
 @Module({
-  imports: [EventsModule, PrismaModule],
+  imports: [EventsModule],
   providers: [InitService],
   exports: [InitService],
 })

--- a/src/modules/attachment/attachment.module.ts
+++ b/src/modules/attachment/attachment.module.ts
@@ -3,13 +3,12 @@ import { Module } from '@nestjs/common';
 import { AttachmentService } from './attachment.service';
 import { AttachmentController } from './attachment.controller';
 import { S3Service } from '../../common/aws/S3/s3.service';
-import { PrismaService } from '../../common/database/prisma';
 import { CipherModule } from '../../common/cipher/cipher.module';
 import { STSService } from '../../common/aws/STS/sts.service';
 
 @Module({
   controllers: [AttachmentController],
-  providers: [AttachmentService, S3Service, STSService, PrismaService],
+  providers: [AttachmentService, S3Service, STSService],
   exports: [AttachmentService],
   imports: [CipherModule],
 })

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -3,7 +3,6 @@ import { ConfigService } from '@nestjs/config';
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 
-import { PrismaModule } from '../../common/database/prisma/prisma.module';
 import { UsersModule } from '../users/users.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
@@ -15,7 +14,6 @@ import { EnvSchema } from '../../config';
   controllers: [AuthController],
   exports: [AuthService],
   imports: [
-    PrismaModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     UsersModule,
     JwtModule.registerAsync({

--- a/src/modules/users/users.module.ts
+++ b/src/modules/users/users.module.ts
@@ -2,12 +2,11 @@ import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 import { EmailModule } from '../../common/email/email.module';
-import { PrismaService } from '../../common/database/prisma';
 import { CipherModule } from '../../common/cipher/cipher.module';
 
 @Module({
   controllers: [UsersController],
-  providers: [UsersService, PrismaService],
+  providers: [UsersService],
   imports: [EmailModule, CipherModule],
   exports: [UsersService],
 })


### PR DESCRIPTION
Marked PrismaModule as global to reduce redundancy across modules. Removed explicit imports of PrismaModule and PrismaService across different modules, simplifying dependency management.