### PR TITLE
chore: Add Prisma seed and unseed scripts with initial seeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,12 @@
     "format-staged-files": "prettier --write",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
-    "rebase:origin": "git fetch && git rebase origin/main"
+    "rebase:origin": "git fetch && git rebase origin/main",
+    "prisma:seed": "prisma db seed",
+    "prisma:unseed": "ts-node ./prisma/seeds/seed.ts unseed"
+  },
+  "prisma": {
+    "seed": "ts-node ./prisma/seeds/seed.ts seed"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.787.0",

--- a/prisma/seeds/accounts.ts
+++ b/prisma/seeds/accounts.ts
@@ -1,0 +1,23 @@
+import { Logger } from '@nestjs/common';
+import { transactionClient } from './seed';
+
+export async function seedAccounts(client: transactionClient, logger: Logger) {
+  logger.log('Initializing accounts seed...');
+  await client.account.createMany({
+    data: [
+      {
+        id: '35cfb296-f8c3-409e-9e52-fc493c2a2c66',
+      },
+      {
+        id: '7b668092-629d-4b21-9757-b7b2fb1faafb',
+      },
+    ],
+  });
+  logger.log('Accounts seed successfully initialized.');
+}
+
+export async function unseedAccounts(client: transactionClient, logger: Logger) {
+  logger.log('Unseeding accounts...');
+  await client.account.deleteMany();
+  logger.log('Accounts successfully unseeded.');
+}

--- a/prisma/seeds/seed.ts
+++ b/prisma/seeds/seed.ts
@@ -1,0 +1,67 @@
+import { DefaultArgs } from '@prisma/client/runtime/client';
+import { Prisma, PrismaClient } from '@prisma/client';
+import { Logger } from '@nestjs/common';
+
+import { unseedSignUpVerificationCodes } from './sign-up-verification-codes';
+import { seedAccounts, unseedAccounts } from './accounts';
+import { seedUsers, unseedUsers } from './users';
+
+const client = new PrismaClient();
+const logger = new Logger('Seeder');
+const allowedOperations = ['seed', 'unseed'] as const;
+type OperationFunction = (client: PrismaClient, logger: Logger) => Promise<void>;
+export type transactionClient = Omit<
+  PrismaClient<Prisma.PrismaClientOptions, never, DefaultArgs>,
+  '$on' | '$connect' | '$disconnect' | '$use' | '$transaction' | '$extends'
+>;
+
+const operationFunctionMap: Record<(typeof allowedOperations)[number], OperationFunction> = {
+  seed: async (client, logger) => {
+    await client.$transaction(
+      async (client) => {
+        await seedAccounts(client, logger);
+        await seedUsers(client, logger);
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead },
+    );
+  },
+  unseed: async (client, logger) => {
+    await client.$transaction(
+      async (client) => {
+        await unseedSignUpVerificationCodes(client, logger);
+        await unseedUsers(client, logger);
+        await unseedAccounts(client, logger);
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead },
+    );
+  },
+};
+
+const handleOperationError = async (error: unknown) => {
+  logger.error(error);
+  await client.$disconnect();
+  logger.error('Operation failed!');
+  process.exit(1);
+};
+
+const performOperation = async (operation: string) => {
+  try {
+    if (!allowedOperations.includes(operation as (typeof allowedOperations)[number])) {
+      throw new Error(`Invalid Operation: Choose either ${allowedOperations.join(' or ')}`);
+    }
+
+    logger.log(`Executing operation: ${operation}`);
+    await operationFunctionMap[operation as (typeof allowedOperations)[number]](client, logger);
+    await client.$disconnect();
+    logger.log('Operation successful!');
+  } catch (error) {
+    await handleOperationError(error);
+  }
+};
+
+(async () => {
+  const selectedOperation = process.argv[2];
+  await performOperation(selectedOperation);
+})()
+  .then(() => {})
+  .catch(() => {});

--- a/prisma/seeds/sign-up-verification-codes.ts
+++ b/prisma/seeds/sign-up-verification-codes.ts
@@ -1,0 +1,8 @@
+import { Logger } from '@nestjs/common';
+import { transactionClient } from './seed';
+
+export async function unseedSignUpVerificationCodes(client: transactionClient, logger: Logger) {
+  logger.log('Unseeding sign-up verification codes...');
+  await client.signUpVerificationCode.deleteMany();
+  logger.log('Sign-up verification codes successfully unseeded.');
+}

--- a/prisma/seeds/users.ts
+++ b/prisma/seeds/users.ts
@@ -1,0 +1,37 @@
+import { Logger } from '@nestjs/common';
+
+import { transactionClient } from './seed';
+import * as bcrypt from 'bcrypt';
+
+export async function seedUsers(client: transactionClient, logger: Logger) {
+  logger.log('Initializing users seed...');
+  const password = await bcrypt.hash('Test123!', Number(process.env.BCRYPT_ROUNDS)); // prisma will load .env
+
+  await client.user.createMany({
+    data: [
+      {
+        id: '127b21cd-7924-418d-be8e-a42e0f47c60a',
+        name: 'John Doe',
+        email: 'john.doe@gmail.com',
+        accountId: '35cfb296-f8c3-409e-9e52-fc493c2a2c66',
+        verified: true,
+        password,
+      },
+      {
+        id: '4c6b3fa9-bc44-4c9a-953c-9dd5807bd695',
+        name: 'Jane Doe',
+        email: 'jane.doe@gmail.com',
+        password,
+        verified: true,
+        accountId: '7b668092-629d-4b21-9757-b7b2fb1faafb',
+      },
+    ],
+  });
+  logger.log('Users seed successfully initialized.');
+}
+
+export async function unseedUsers(client: transactionClient, logger: Logger) {
+  logger.log('Unseeding users...');
+  await client.user.deleteMany();
+  logger.log('Users successfully unseeded.');
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "data"]
+  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "data", ".idea", "prisma/seeds/**/*"]
 }


### PR DESCRIPTION
# Main changes

- [X] Introduce `prisma:seed` and `prisma:unseed` scripts for database seeding and unseeding, including accounts, users, and sign-up verification codes.
- [X] Implement seed logic in modular TypeScript files under `prisma/seeds`.
- [X] Update `tsconfig.build.json` to exclude seed files from the build artifacts.